### PR TITLE
Modernize theme for latest WordPress

### DIFF
--- a/UPGRADE_PLAN.md
+++ b/UPGRADE_PLAN.md
@@ -1,0 +1,45 @@
+# WordPress Upgrade Plan for the Redmond Inspired Theme
+
+## 1. Establish a Baseline
+- Confirm the site is currently running the Redmond Inspired theme version `0.0.1` and capture a full database and `wp-content` backup before touching production. The theme header in `style.css` documents the legacy version we are starting from.【F:style.css†L1-L12】
+- Stand up a local WordPress environment that mirrors production (PHP version, active plugins, multisite state) so the upgrade and fixes can be rehearsed safely.
+- Import a recent production database snapshot and media library into the sandbox. Validate that the theme renders correctly to ensure we have a reliable “before” reference.
+
+## 2. Update the Core WordPress Version
+- Identify the target WordPress release (e.g., 6.4.x or newer) and review the official release notes for breaking changes affecting themes (block editor expectations, `wp_nav_menu` updates, script loading changes, etc.).
+- Upgrade the sandbox site incrementally through any major version gaps (e.g., 4.x → 5.x → 6.x) to catch migration tasks such as database upgrades or Gutenberg-related configuration.
+- After each core upgrade, run the WordPress database upgrade routine and check the site for fatal errors, warnings, or layout breakages.
+
+## 3. Theme Compatibility Audit
+- Run automated checks: `wp theme validate`, Theme Check, and WordPress Coding Standards (PHPCS) to surface deprecated API usage, escaping issues, and coding-standard regressions in files like `functions.php` and `header.php`.
+- Manually browse the site in the sandbox, especially AJAX-driven UI such as the “Start” menu and modal windows controlled by `functions.js`, to confirm interactions still work under the new core JavaScript and jQuery versions.【F:functions.js†L1-L89】
+
+## 4. Replace Deprecated WordPress APIs
+- Update `header.php` to rely on modern authentication globals (`wp_get_current_user()`) instead of the deprecated `get_currentuserinfo()` helper.【F:header.php†L1-L24】
+- Replace the custom `<title>` tag generation and the `wp_title` filter in `functions.php` with the `title-tag` theme support introduced in WordPress 4.1.【F:functions.php†L36-L63】【F:header.php†L8-L16】
+- Review AJAX endpoints in `bin/ajax.php` to ensure they validate nonces and sanitize payloads, and modernize responses away from `WP_Ajax_Response` if needed. Adopt `wp_send_json_success()` / `wp_send_json_error()` for consistency with current best practices.【F:bin/ajax.php†L1-L73】
+
+## 5. Modernize Theme Supports and Assets
+- In `functions.php`, add support for features expected by recent WordPress releases (block editor styles, responsive embeds, custom logos) while keeping the theme’s classic aesthetic.【F:functions.php†L36-L63】
+- Audit script and style registration in `redmond_theme_add_scripts_and_styles()` (located in the `bin` directory) to ensure dependencies are enqueued with proper versioning and compatibility with the bundled jQuery UI from modern WordPress.【F:functions.php†L36-L63】
+- Confirm all static assets referenced via `REDMONDURI` still exist and consider migrating icon resources to SVG or modern formats if practical.【F:header.php†L24-L78】
+
+## 6. Hardening and Performance
+- Review the numerous `remove_action( 'wp_head', ... )` calls in `functions.php` to ensure we only strip the elements we truly do not need, balancing performance with modern WordPress features (e.g., RSS feeds for discoverability).【F:functions.php†L64-L86】
+- Add nonce checks and capability validations to AJAX actions (`redmond_getpost_callback`, `redmond_getarchive_callback`, `redmond_getauthor_callback`) before trusting `$_POST` data.【F:bin/ajax.php†L1-L110】
+- Evaluate whether the New Relic integrations are still required; guard them behind feature flags so the theme functions without the extension when running on hosts without New Relic.【F:functions.php†L8-L35】
+
+## 7. Block Editor (Gutenberg) Compatibility
+- Test creating and editing posts in the block editor to see how the theme’s CSS applies to blocks. Extend `editor-style.css` support or add block-specific styles so default blocks match the theme’s Windows XP aesthetic.
+- Provide template parts or block patterns, if feasible, that mimic the existing layout to ease content creation while maintaining the retro feel.
+
+## 8. Quality Assurance and Rollout
+- Regression test all front-end interactions, including AJAX-driven dialogs, login/logout flows, and customizer options supplied via `bin/customizer.php`.
+- Verify responsive behavior and cross-browser support, paying special attention to fixed-position UI like the taskbar implemented in `style.css` and the clock controlled by `functions.js`.【F:style.css†L13-L123】【F:functions.js†L1-L89】
+- Once confidence is high, deploy the upgraded theme and core to a staging environment, secure stakeholder sign-off, and then schedule the production release during a low-traffic window. Keep the previous version snapshot for quick rollback.
+
+## 9. Post-Upgrade Monitoring
+- Monitor application logs, browser console output, and (if enabled) New Relic APM dashboards for errors related to the theme.
+- Capture user feedback and address any regressions promptly, committing fixes back into version control.
+
+Following this plan will let us upgrade WordPress to the latest release while preserving the Redmond Inspired theme’s distinctive UX and ensuring it meets current platform expectations.

--- a/bin/ajax.php
+++ b/bin/ajax.php
@@ -1,131 +1,151 @@
 <?php
-	defined( 'ABSPATH' ) || die( 'Sorry, but you cannot access this page directly.' );
+        defined( 'ABSPATH' ) || die( 'Sorry, but you cannot access this page directly.' );
 
-	function redmond_getpost_callback() {
-		$POST = stripslashes_deep( $_POST );
-		$postId = intval( $POST['post'] );
-		$postData = get_post( $postId );
-		$postData->post_content = apply_filters( 'the_content' , $postData->post_content );
-		$comments = get_comments( array( 'post_id' => $postData->ID, 'status' => 'approve' ) );
-		$res_data = array(
-			'ID' => $postData->ID,
-			'post_title' => $postData->post_title,
-			'post_content' => redmond_add_comments_to_content( $postData->post_content, $postData->ID ),
-			'post_icon' => redmond_get_post_icon( $postData->ID ),
-			'task_name' => 'post_' . $postData->ID,
-			'comments' => $comments,
-			'fileMenu' => get_file_menu_for_post( $postData->ID ),
-		);
-		$response = array(
-			'what' => 'login',
-			'action' => 'login',
-			'id' => '1',
-			'data' => json_encode( $res_data ),
-		);
-		$xmlResponse = new WP_Ajax_Response( $response );
-		$xmlResponse->send();
-	}
+        function redmond_getpost_callback() {
+                check_ajax_referer( 'redmond_ajax_nonce', 'nonce' );
 
-	function redmond_add_comments_to_content( $content, $post_id ) {
-		$content = '<article>' . $content . "\r\n";
-		if ( comments_open( $post_id ) && get_comments_number( $post_id ) > 0 ) {
-			$comments = get_comments( array( 'post_id' => $post_id, 'status' => 'approve' ) );
-			$content .= '<hr />' . "\r\n";
-			$content .= '<h4>' . __( 'Comments:', RTEXTDOMAIN ) . '</h4>' . "\r\n";
-			$content .= '<ul class="list-group">' . "\r\n";
-			foreach ( $comments as $comment ) {
-				$content .= '<li class="list-group-item">' . "\r\n";
-				$content .= '<a href="' . esc_url( $comment->comment_author_url ) . '" target="_blank">' . get_avatar( $comment->comment_author_email , 64 ) . '</a>' . "\r\n";
-				$content .= '<h5 class="list-group-item-heading">' . esc_html( $comment->comment_author ) . '</h5>' . "\r\n";
-				$content .= wpautop( esc_html( $comment->comment_content ) );
-				$content .= '</li>' . "\r\n";
-			}
-			$content .= '</ul>' . "\r\n";
-		}
-		$content .= '</article>' . "\r\n";
-		return $content;
-	}
+                if ( empty( $_POST['post'] ) ) {
+                        wp_send_json_error( array( 'message' => __( 'Invalid post request.', RTEXTDOMAIN ) ), 400 );
+                }
 
-	function redmond_getarchive_callback() {
-		$POST = stripslashes_deep( $_POST );
-		$response = array(
-			'what' => 'login',
-			'action' => 'login',
-			'id' => '1',
-			'data' => json_encode( $POST ),
-		);
-		$data = array(
-			'html' => '',
-			'breadcrumbs' => '',
-			'menu' => array(),
-			'title' => __( 'Archive', RTEXTDOMAIN ),
-			'icon' => get_theme_mod( 'redmond_default_documents_icon' , REDMONDURI . '/resources/docs.ico' ),
-			'taskname' => null,
-		);
-		switch ( $POST['taxonomy'] ) {
-			case 'tags':
-				$data['html'] = redmond_generate_folder_shortcuts_from_tag( $POST['archive'] );
-				$data['menu']['close'] = array(
-					'title' => __( 'Close', RTEXTDOMAIN ),
-					'onclick' => 'redmond_close_this(this)',
-				);
-				$data['taskname'] = 'tag_archive_' . esc_html( $POST['archive'] );
-				$data['title'] = ( 'all' !== $POST['archive'] ) ? get_tag( $POST['archive'] )->name : __( 'All Tags', RTEXTDOMAIN );
-				break;
+                $post_id = absint( wp_unslash( $_POST['post'] ) );
+                if ( ! $post_id ) {
+                        wp_send_json_error( array( 'message' => __( 'Invalid post request.', RTEXTDOMAIN ) ), 400 );
+                }
 
-			default:
-				$data['html'] = redmond_generate_folder_shortcuts_from_category( $POST['archive'] );
-				$data['menu']['close'] = array(
-					'title' => __( 'Close', RTEXTDOMAIN ),
-					'onclick' => 'redmond_close_this(this)',
-				);
-				$data['title'] = ( 'all' !== $POST['archive'] ) ? get_the_category_by_ID( $POST['archive'] ) : __( 'All Categories', RTEXTDOMAIN );
-				$data['taskname'] = 'cat_archive_' . esc_html( $POST['archive'] );
-				break;
-		}
-		$response['data'] = json_encode( $data );
-		$xmlResponse = new WP_Ajax_Response( $response );
-		$xmlResponse->send();
-	}
+                $post = get_post( $post_id );
+                if ( empty( $post ) || 'publish' !== get_post_status( $post ) ) {
+                        wp_send_json_error( array( 'message' => __( 'The requested post could not be found.', RTEXTDOMAIN ) ), 404 );
+                }
 
-	function redmond_getsearch_callback() {
-		$POST = stripslashes_deep( $_POST );
-		$search = ( array_key_exists( 'search', $POST ) ) ? $POST['search'] : '';
-		$response = array(
-			'what' => 'login',
-			'action' => 'login',
-			'id' => '1',
-			'data' => json_encode( array( 'html' => redmond_generate_search_results( $search ) ) ),
-		);
-		$xmlResponse = new WP_Ajax_Response( $response );
-		$xmlResponse->send();
-	}
+                $content = apply_filters( 'the_content', $post->post_content );
+                $content = redmond_add_comments_to_content( $content, $post->ID );
 
-	function redmond_getauthor_callback() {
-		$POST = stripslashes_deep( $_POST );
-		$response = array(
-			'what' => 'login',
-			'action' => 'login',
-			'id' => '1',
-			'data' => json_encode( $POST ),
-		);
-		$data = array(
-			'html' => '',
-			'breadcrumbs' => '',
-			'menu' => array(),
-			'title' => __( 'Author', RTEXTDOMAIN ),
-			'icon' => get_theme_mod( 'redmond_default_documents_icon' , REDMONDURI . '/resources/docs.ico' ),
-			'taskname' => null,
-		);
-		$data['menu']['close'] = array(
-			'title' => __( 'Close', RTEXTDOMAIN ),
-			'onclick' => 'redmond_close_this(this)',
-		);
-		$data['title'] = ( 'all' !== $POST['author'] ) ? get_userdata( intval( $POST['author'] ) )->display_name : __( 'All Authors', RTEXTDOMAIN );
-		$data['taskname'] = 'author_archive_' . esc_html( $POST['author'] );
-		$data['html'] = redmond_generate_folder_shortcuts_from_author( $POST['author'] );
-		$response['data'] = json_encode( $data );
-		$xmlResponse = new WP_Ajax_Response( $response );
-		$xmlResponse->send();
-	}
+                $data = array(
+                        'ID'          => $post->ID,
+                        'post_title'  => get_the_title( $post ),
+                        'post_content'=> $content,
+                        'post_icon'   => redmond_get_post_icon( $post->ID ),
+                        'task_name'   => 'post_' . $post->ID,
+                        'fileMenu'    => get_file_menu_for_post( $post->ID ),
+                );
+
+                wp_send_json_success( $data );
+        }
+
+        function redmond_add_comments_to_content( $content, $post_id ) {
+                $content = '<article>' . $content . "\r\n";
+                if ( comments_open( $post_id ) && get_comments_number( $post_id ) > 0 ) {
+                        $comments = get_comments( array( 'post_id' => $post_id, 'status' => 'approve' ) );
+                        $content .= '<hr />' . "\r\n";
+                        $content .= '<h4>' . __( 'Comments:', RTEXTDOMAIN ) . '</h4>' . "\r\n";
+                        $content .= '<ul class="list-group">' . "\r\n";
+                        foreach ( $comments as $comment ) {
+                                $content .= '<li class="list-group-item">' . "\r\n";
+                                $content .= '<a href="' . esc_url( $comment->comment_author_url ) . '" target="_blank">' . get_avatar( $comment->comment_author_email , 64 ) . '</a>' . "\r\n";
+                                $content .= '<h5 class="list-group-item-heading">' . esc_html( $comment->comment_author ) . '</h5>' . "\r\n";
+                                $content .= wpautop( esc_html( $comment->comment_content ) );
+                                $content .= '</li>' . "\r\n";
+                        }
+                        $content .= '</ul>' . "\r\n";
+                }
+                $content .= '</article>' . "\r\n";
+                return $content;
+        }
+
+        function redmond_getarchive_callback() {
+                check_ajax_referer( 'redmond_ajax_nonce', 'nonce' );
+
+                $taxonomy = ! empty( $_POST['taxonomy'] ) ? sanitize_key( wp_unslash( $_POST['taxonomy'] ) ) : 'category';
+                $archive  = isset( $_POST['archive'] ) ? wp_unslash( $_POST['archive'] ) : 'all';
+
+                if ( 'all' !== $archive ) {
+                        $archive = absint( $archive );
+                }
+
+                $data = array(
+                        'html'       => '',
+                        'breadcrumbs'=> '',
+                        'menu'       => array(),
+                        'title'      => __( 'Archive', RTEXTDOMAIN ),
+                        'icon'       => get_theme_mod( 'redmond_default_documents_icon', REDMONDURI . '/resources/docs.ico' ),
+                        'taskname'   => null,
+                );
+
+                switch ( $taxonomy ) {
+                        case 'tags':
+                                $data['html'] = redmond_generate_folder_shortcuts_from_tag( ( 'all' === $archive ) ? 'all' : $archive );
+                                $data['menu']['close'] = array(
+                                        'title'   => __( 'Close', RTEXTDOMAIN ),
+                                        'onclick' => 'redmond_close_this(this)',
+                                );
+                                $data['taskname'] = 'tag_archive_' . esc_attr( ( 'all' === $archive ) ? 'all' : $archive );
+                                if ( 'all' !== $archive && $archive ) {
+                                        $tag = get_tag( $archive );
+                                        $data['title'] = ( $tag instanceof WP_Term ) ? $tag->name : __( 'Tag', RTEXTDOMAIN );
+                                } else {
+                                        $data['title'] = __( 'All Tags', RTEXTDOMAIN );
+                                }
+                                break;
+
+                        default:
+                                $data['html'] = redmond_generate_folder_shortcuts_from_category( ( 'all' === $archive ) ? 'all' : $archive );
+                                $data['menu']['close'] = array(
+                                        'title'   => __( 'Close', RTEXTDOMAIN ),
+                                        'onclick' => 'redmond_close_this(this)',
+                                );
+                                if ( 'all' !== $archive && $archive ) {
+                                        $category_title = get_the_category_by_ID( $archive );
+                                        $data['title']   = $category_title ? $category_title : __( 'Category', RTEXTDOMAIN );
+                                } else {
+                                        $data['title'] = __( 'All Categories', RTEXTDOMAIN );
+                                }
+                                $data['taskname'] = 'cat_archive_' . esc_attr( ( 'all' === $archive ) ? 'all' : $archive );
+                                break;
+                }
+
+                wp_send_json_success( $data );
+        }
+
+        function redmond_getsearch_callback() {
+                check_ajax_referer( 'redmond_ajax_nonce', 'nonce' );
+
+                $search = isset( $_POST['search'] ) ? sanitize_text_field( wp_unslash( $_POST['search'] ) ) : '';
+
+                wp_send_json_success( array( 'html' => redmond_generate_search_results( $search ) ) );
+        }
+
+        function redmond_getauthor_callback() {
+                check_ajax_referer( 'redmond_ajax_nonce', 'nonce' );
+
+                $author = isset( $_POST['author'] ) ? wp_unslash( $_POST['author'] ) : 'all';
+                if ( 'all' !== $author ) {
+                        $author = absint( $author );
+                }
+
+                $data = array(
+                        'html'       => '',
+                        'breadcrumbs'=> '',
+                        'menu'       => array(),
+                        'title'      => __( 'Author', RTEXTDOMAIN ),
+                        'icon'       => get_theme_mod( 'redmond_default_documents_icon', REDMONDURI . '/resources/docs.ico' ),
+                        'taskname'   => null,
+                );
+                $data['menu']['close'] = array(
+                        'title'   => __( 'Close', RTEXTDOMAIN ),
+                        'onclick' => 'redmond_close_this(this)',
+                );
+
+                if ( 'all' !== $author && $author ) {
+                        $user          = get_userdata( $author );
+                        $data['title'] = ( $user instanceof WP_User ) ? $user->display_name : __( 'Author', RTEXTDOMAIN );
+                } else {
+                        $data['title'] = __( 'All Authors', RTEXTDOMAIN );
+                }
+
+                $data['taskname'] = 'author_archive_' . esc_attr( ( 'all' === $author ) ? 'all' : $author );
+                $data['html']     = redmond_generate_folder_shortcuts_from_author( ( 'all' === $author ) ? 'all' : $author );
+
+                wp_send_json_success( $data );
+        }
 ?>

--- a/bin/client.php
+++ b/bin/client.php
@@ -1,87 +1,87 @@
 <?php
 	defined( 'ABSPATH' ) || die( 'Sorry, but you cannot access this page directly.' );
 
-	$redmond_scripts = array(
-		array(
-			'handle' => 'bootstrap',
-			'src' => '//cdnjs.cloudflare.com/ajax/libs/twitter-bootstrap/3.2.0/js/bootstrap.min.js',
-			'deps' => array('jquery'),
-			'ver' => null,
-			'in_footer' => true,
-		),
-		array(
-			'handle' => 'validate',
-			'src' => '//cdnjs.cloudflare.com/ajax/libs/jquery-validate/1.13.1/jquery.validate.min.js',
-			'deps' => array('jquery'),
-			'ver' => null,
-			'in_footer' => true,
-		),
-		array(
-			'handle' => 'validate-additional',
-			'src' => '//cdnjs.cloudflare.com/ajax/libs/jquery-validate/1.13.1/additional-methods.min.js',
-			'deps' => array('jquery'),
-			'ver' => null,
-			'in_footer' => true,
-		),
-		array(
-			'handle' => 'chosen',
-			'src' => '//cdnjs.cloudflare.com/ajax/libs/chosen/1.1.0/chosen.jquery.min.js',
-			'deps' => array('jquery'),
-			'ver' => null,
-			'in_footer' => true,
-		),
-		array(
-			'handle' => 'redmond-dialogs',
-			'src' => REDMONDURI . '/resources/redmond-dialogs.js',
-			'deps' => array(
-				'jquery',
-				'jquery-ui-dialog',
-				'jquery-ui-core',
-			),
-			'ver' => '0.0.1',
-			'in_footer' => true,
-			'needsTranslation' => true,
-		),
-		array(
-			'handle' => 'redmond',
-			'src' => REDMONDURI . '/functions.js',
-			'deps' => array(
-				'jquery',
-				'redmond-dialogs',
-				'chosen',
-				'bootstrap',
-				'wp-ajax-response',
-				'validate',
-				'validate-additional',
-			),
-			'ver' => '0.0.1',
-			'in_footer' => true,
-			'needsTranslation' => true,
-		),
-	);
-	$redmond_styles = array(
-		array(
-			'handle' => 'chosen',
-			'src' => '//cdnjs.cloudflare.com/ajax/libs/chosen/1.4.1/chosen.min.css',
-			'deps' => array(),
-			'ver' => null,
-			'media' => 'all',
-		),
-		array(
-			'handle' => 'bootstrap',
-			'src' => '//cdnjs.cloudflare.com/ajax/libs/twitter-bootstrap/3.3.4/css/bootstrap.min.css',
-			'deps' => array(),
-			'ver' => null,
-			'media' => 'all',
-		),
-		array(
-			'handle' => 'redmond',
-			'src' => REDMONDURI . '/style.css',
-			'deps' => array('chosen', 'bootstrap'),
-			'ver' => '0.0.1',
-			'media' => 'all',
-		),
-	);
+        $redmond_scripts = array(
+                array(
+                        'handle' => 'bootstrap',
+                        'src' => 'https://cdnjs.cloudflare.com/ajax/libs/twitter-bootstrap/3.4.1/js/bootstrap.min.js',
+                        'deps' => array( 'jquery' ),
+                        'ver' => '3.4.1',
+                        'in_footer' => true,
+                ),
+                array(
+                        'handle' => 'validate',
+                        'src' => 'https://cdnjs.cloudflare.com/ajax/libs/jquery-validate/1.19.5/jquery.validate.min.js',
+                        'deps' => array( 'jquery' ),
+                        'ver' => '1.19.5',
+                        'in_footer' => true,
+                ),
+                array(
+                        'handle' => 'validate-additional',
+                        'src' => 'https://cdnjs.cloudflare.com/ajax/libs/jquery-validate/1.19.5/additional-methods.min.js',
+                        'deps' => array( 'jquery', 'validate' ),
+                        'ver' => '1.19.5',
+                        'in_footer' => true,
+                ),
+                array(
+                        'handle' => 'chosen',
+                        'src' => 'https://cdnjs.cloudflare.com/ajax/libs/chosen/1.8.7/chosen.jquery.min.js',
+                        'deps' => array( 'jquery' ),
+                        'ver' => '1.8.7',
+                        'in_footer' => true,
+                ),
+                array(
+                        'handle' => 'redmond-dialogs',
+                        'src' => REDMONDURI . '/resources/redmond-dialogs.js',
+                        'deps' => array(
+                                'jquery',
+                                'jquery-ui-dialog',
+                                'jquery-ui-core',
+                        ),
+                        'ver' => REDMOND_THEME_VERSION,
+                        'in_footer' => true,
+                        'needsTranslation' => true,
+                ),
+                array(
+                        'handle' => 'redmond',
+                        'src' => REDMONDURI . '/functions.js',
+                        'deps' => array(
+                                'jquery',
+                                'redmond-dialogs',
+                                'chosen',
+                                'bootstrap',
+                                'wp-ajax-response',
+                                'validate',
+                                'validate-additional',
+                        ),
+                        'ver' => REDMOND_THEME_VERSION,
+                        'in_footer' => true,
+                        'needsTranslation' => true,
+                ),
+        );
+        $redmond_styles = array(
+                array(
+                        'handle' => 'chosen',
+                        'src' => 'https://cdnjs.cloudflare.com/ajax/libs/chosen/1.8.7/chosen.min.css',
+                        'deps' => array(),
+                        'ver' => '1.8.7',
+                        'media' => 'all',
+                ),
+                array(
+                        'handle' => 'bootstrap',
+                        'src' => 'https://cdnjs.cloudflare.com/ajax/libs/twitter-bootstrap/3.4.1/css/bootstrap.min.css',
+                        'deps' => array(),
+                        'ver' => '3.4.1',
+                        'media' => 'all',
+                ),
+                array(
+                        'handle' => 'redmond',
+                        'src' => REDMONDURI . '/style.css',
+                        'deps' => array( 'chosen', 'bootstrap' ),
+                        'ver' => REDMOND_THEME_VERSION,
+                        'media' => 'all',
+                ),
+        );
 	$redmond_js_translations = array(
 		'ajaxurl' => admin_url( 'admin-ajax.php' ),
 		'searchIcon' => get_theme_mod( 'redmond_default_search_icon' , REDMONDURI . '/resources/sitesearch.ico' ),
@@ -90,10 +90,11 @@
 		'externalPageIcon' => get_theme_mod( 'redmond_external_page_icon' , REDMONDURI . '/resources/external.ico' ),
 		'errorSound' => get_theme_mod( 'redmond_default_error_sound' , REDMONDURI . '/resources/error.wav' ),
 		'openSound' => get_theme_mod( 'redmond_default_open_sound' , REDMONDURI . '/resources/open.wav' ),
-		'loginSound' => get_theme_mod( 'redmond_default_startup_sound' , REDMONDURI . '/resources/logon.wav' ),
-		'playLoginSounds' => ( isset( $_COOKIE['returning_visit'] ) ) ? false : true,
-		'file' => __( 'File', RTEXTDOMAIN ),
-		'close' => __( 'Exit', RTEXTDOMAIN ),
+                'loginSound' => get_theme_mod( 'redmond_default_startup_sound' , REDMONDURI . '/resources/logon.wav' ),
+                'playLoginSounds' => ( isset( $_COOKIE['returning_visit'] ) ) ? false : true,
+                'nonce' => wp_create_nonce( 'redmond_ajax_nonce' ),
+                'file' => __( 'File', RTEXTDOMAIN ),
+                'close' => __( 'Exit', RTEXTDOMAIN ),
 		'closetext' => __( 'Close', RTEXTDOMAIN ),
 		'errTitle' => __( 'Error', RTEXTDOMAIN ),
 		'ajaxerror' => __( 'An error has occured while attempting to retrieve the requested information. Please check the error console for more information.', RTEXTDOMAIN ),
@@ -109,60 +110,61 @@
 
 	function redmond_theme_add_scripts_and_styles() {
 		global $redmond_scripts, $redmond_styles, $redmond_js_translations;
-		foreach ( $redmond_scripts as $script ) {
-			wp_deregister_script( $script['handle'] );
-			wp_register_script( $script['handle'], $script['src'], $script['deps'], $script['ver'], $script['in_footer'] );
-			if ( array_key_exists( 'needsTranslation', $script ) && true == $script['needsTranslation'] ) {
-				wp_localize_script( $script['handle'] , 'redmond_terms' , $redmond_js_translations );
-			}
-			wp_enqueue_script( $script['handle'] );
-		}
-		foreach ( $redmond_styles as $style ) {
-			wp_deregister_style( $style['handle'] );
-			wp_register_style( $style['handle'], $style['src'], $style['deps'], ( array_key_exists( 'ver', $style ) ) ? $style['ver'] : null, $style['media'] );
-			wp_enqueue_style( $style['handle'] );
-		}
+                foreach ( $redmond_scripts as $script ) {
+                        wp_register_script( $script['handle'], $script['src'], $script['deps'], $script['ver'], $script['in_footer'] );
+                        if ( array_key_exists( 'needsTranslation', $script ) && true === $script['needsTranslation'] ) {
+                                wp_localize_script( $script['handle'], 'redmond_terms', $redmond_js_translations );
+                        }
+                        wp_enqueue_script( $script['handle'] );
+                }
+                foreach ( $redmond_styles as $style ) {
+                        wp_register_style( $style['handle'], $style['src'], $style['deps'], ( array_key_exists( 'ver', $style ) ) ? $style['ver'] : null, $style['media'] );
+                        wp_enqueue_style( $style['handle'] );
+                }
 	}
 
-	function redmond_add_menus() {
-		$menus = array(
-			'quick_launch' => __( 'Quick Launch Menu', RTEXTDOMAIN ),
-			'desktop' => __( 'Desktop Menu', RTEXTDOMAIN ),
-			'start' => __( 'Start Menu', RTEXTDOMAIN ),
-		);
-		register_nav_menus( $menus );
-	}
+        function redmond_add_menus() {
+                $menus = array(
+                        'quick_launch' => __( 'Quick Launch Menu', RTEXTDOMAIN ),
+                        'desktop' => __( 'Desktop Menu', RTEXTDOMAIN ),
+                        'start' => __( 'Start Menu', RTEXTDOMAIN ),
+                );
+                register_nav_menus( $menus );
+        }
 
-	function redmond_add_theme_supports() {
-		$redmond_background_defaults = array(
-			'default-color' => '3a6ea5',
-			'wp-head-callback' => 'redmond_custom_background_printer',
-		);
-		add_theme_support( 'post-thumbnails' );
-		add_theme_support( 'custom-background' ,$redmond_background_defaults );
-	}
+        function redmond_add_theme_supports() {
+                $redmond_background_defaults = array(
+                        'default-color' => '3a6ea5',
+                        'wp-head-callback' => 'redmond_custom_background_printer',
+                );
+
+                load_theme_textdomain( RTEXTDOMAIN, get_template_directory() . '/languages' );
+
+                add_theme_support( 'post-thumbnails' );
+                add_theme_support( 'custom-background', $redmond_background_defaults );
+                add_theme_support( 'custom-logo', array(
+                        'height' => 64,
+                        'width' => 64,
+                        'flex-height' => true,
+                        'flex-width' => true,
+                ) );
+                add_theme_support( 'automatic-feed-links' );
+                add_theme_support( 'title-tag' );
+                add_theme_support( 'html5', array( 'search-form', 'comment-form', 'comment-list', 'gallery', 'caption', 'style', 'script' ) );
+                add_theme_support( 'responsive-embeds' );
+                add_theme_support( 'wp-block-styles' );
+                add_theme_support( 'editor-styles' );
+                add_editor_style( 'resources/editor-style.css' );
+                add_theme_support( 'customize-selective-refresh-widgets' );
+        }
 
 	function redmond_user_gravatar( $email, $size = 64 ) {
 		return '//www.gravatar.com/avatar/' . md5( strtolower( $email ) ) . '?d=mm&s=' . intval( $size ) . '&r=g';
 	}
 
-	function redmond_filter_wp_title( $title, $sep ) {
-		global $wp_query;
-		switch ( true ) {
-			case is_front_page():
-				$title = get_bloginfo( 'description' );
-				break;
-
-			default:
-				$title = str_replace( ' - ' . get_bloginfo( 'name' ), '', $title );
-				break;
-		}
-		return $title;
-	}
-
-	function redmond_remove_admin_bar() {
-		show_admin_bar( false );
-	}
+        function redmond_remove_admin_bar() {
+                show_admin_bar( false );
+        }
 
 	function redmond_custom_background_printer() {
 		$color = get_theme_mod( 'background_color', get_theme_support( 'custom-background', 'default-color' ) );

--- a/functions.js
+++ b/functions.js
@@ -207,47 +207,33 @@ function open_post_as_dialog( postId ) {
 		url: redmond_terms.ajaxurl,
 		data: {
 			action: 'getpost',
-			post: postId
+			post: postId,
+			nonce: redmond_terms.nonce,
 		},
 		async: true,
 		beforeSend: function() {},
 		cache: false,
 		crossDomain: false,
-		error: function() {
-			do_redmond_error_window( redmond_terms.ajaxerror );
-			console.log('AJAX Error');
+		dataType: 'json',
+		error: function( jqXHR ) {
+			redmondHandleAjaxError( jqXHR );
 		},
 		method: 'POST',
 		success: function( returned ) {
-			var res = wpAjax.parseAjaxResponse( returned );
-			switch(true) {
-				case ( res === false ):
-					do_redmond_error_window( redmond_terms.ajaxerror );
-					console.log('No such AJAX Action');
-					break;
-
-				case ( typeof( res.responses ) == 'undefined' ):
-					do_redmond_error_window( redmond_terms.ajaxerror );
-					console.log('No Parsable Response');
-					break;
-
-				case ( res.responses.length > 0 ):
-					var data = jQuery.parseJSON( res.responses[0].data );
-					redmond_window( data.task_name , data.post_title , data.post_content , data.fileMenu , true, true , data.post_icon );
-					processes[data.task_name].find('article').css({
-						padding: 10,
-					});
-					sounds.open.play();
-					break;
-
-				default:
-					do_redmond_error_window( redmond_terms.ajaxerror );
-					console.log('Unknown Error');
-					break;
+			var data = redmondParseAjaxResponse( returned );
+			if ( false === data ) {
+				redmondHandleAjaxError();
+				return;
 			}
+			redmond_window( data.task_name , data.post_title , data.post_content , data.fileMenu , true, true , data.post_icon );
+			processes[data.task_name].find('article').css({
+				padding: 10,
+			});
+			sounds.open.play();
 		}
 	});
 }
+
 
 function open_archive_as_dialog( archive , taxonomy , targetId ) {
 	if( typeof( taxonomy ) == 'undefined' ) {
@@ -262,57 +248,42 @@ function open_archive_as_dialog( archive , taxonomy , targetId ) {
 			action: 'getarchive',
 			taxonomy: taxonomy,
 			archive: archive,
+			nonce: redmond_terms.nonce,
 		},
 		async: true,
 		beforeSend: function() {},
 		cache: false,
 		crossDomain: false,
-		error: function() {
-			do_redmond_error_window( redmond_terms.ajaxerror );
-			console.log('AJAX Error');
+		dataType: 'json',
+		error: function( jqXHR ) {
+			redmondHandleAjaxError( jqXHR );
 		},
 		method: 'POST',
 		success: function( returned ) {
-			var res = wpAjax.parseAjaxResponse( returned );
-			switch(true) {
-				case ( res === false ):
-					do_redmond_error_window( redmond_terms.ajaxerror );
-					console.log('No such AJAX Action');
-					break;
-
-				case ( typeof( res.responses ) == 'undefined' ):
-					do_redmond_error_window( redmond_terms.ajaxerror );
-					console.log('No Parsable Response');
-					break;
-
-				case ( res.responses.length > 0 ):
-					var data = jQuery.parseJSON( res.responses[0].data );
-					if( typeof( targetId ) !== 'undefined' && jQuery("#" + targetId ).length > 0 ) {
-						jQuery("#"+targetId).dialog('close');
-					}
-					redmond_window( data.taskname , data.title , data.html , data.menu , true, true , data.icon );
-					jQuery("#" + data.taskname).find('a').on('click',function(e) {
-						if( typeof( jQuery(this).attr('id') ) === 'undefined' && typeof( jQuery(this).attr('data-type') ) !== 'undefined' ) {
-							e.preventDefault();
-							switch( jQuery(this).attr('data-type') ) {
-								case 'regular':
-									open_this_as_redmond_dialog(this);
-									break;
-
-								default:
-									open_category_as_redmond_dialog(this);
-									break;
-							}
-						}
-					});
-					sounds.open.play();
-					break;
-
-				default:
-					do_redmond_error_window( redmond_terms.ajaxerror );
-					console.log('Unknown Error');
-					break;
+			var data = redmondParseAjaxResponse( returned );
+			if ( false === data ) {
+				redmondHandleAjaxError();
+				return;
 			}
+			if( typeof( targetId ) !== 'undefined' && jQuery("#" + targetId ).length > 0 ) {
+				jQuery("#"+targetId).dialog('close');
+			}
+			redmond_window( data.taskname , data.title , data.html , data.menu , true, true , data.icon );
+			jQuery("#" + data.taskname).find('a').on('click',function(e) {
+				if( typeof( jQuery(this).attr('id') ) === 'undefined' && typeof( jQuery(this).attr('data-type') ) !== 'undefined' ) {
+					e.preventDefault();
+					switch( jQuery(this).attr('data-type') ) {
+					case 'regular':
+						open_this_as_redmond_dialog(this);
+						break;
+
+					default:
+						open_category_as_redmond_dialog(this);
+						break;
+					}
+				}
+			});
+			sounds.open.play();
 		}
 	});
 }
@@ -326,57 +297,42 @@ function open_redmond_authors_window( author ) {
 		data: {
 			action: 'getauthor',
 			author: author,
+			nonce: redmond_terms.nonce,
 		},
 		async: true,
 		beforeSend: function() {},
 		cache: false,
 		crossDomain: false,
-		error: function() {
-			do_redmond_error_window( redmond_terms.ajaxerror );
-			console.log('AJAX Error');
+		dataType: 'json',
+		error: function( jqXHR ) {
+			redmondHandleAjaxError( jqXHR );
 		},
 		method: 'POST',
 		success: function( returned ) {
-			var res = wpAjax.parseAjaxResponse( returned );
-			switch(true) {
-				case ( res === false ):
-					do_redmond_error_window( redmond_terms.ajaxerror );
-					console.log('No such AJAX Action');
-					break;
-
-				case ( typeof( res.responses ) == 'undefined' ):
-					do_redmond_error_window( redmond_terms.ajaxerror );
-					console.log('No Parsable Response');
-					break;
-
-				case ( res.responses.length > 0 ):
-					var data = jQuery.parseJSON( res.responses[0].data );
-					if( typeof( targetId ) !== 'undefined' && jQuery("#" + targetId ).length > 0 ) {
-						jQuery("#"+targetId).dialog('close');
-					}
-					redmond_window( data.taskname , data.title , data.html , data.menu , true, true , data.icon );
-					jQuery("#" + data.taskname).find('a').on('click',function(e) {
-						if( typeof( jQuery(this).attr('id') ) === 'undefined' && typeof( jQuery(this).attr('data-type') ) !== 'undefined' ) {
-							e.preventDefault();
-							switch( jQuery(this).attr('data-type') ) {
-								case 'regular':
-									open_this_as_redmond_dialog(this);
-									break;
-
-								default:
-									open_redmond_authors_window( jQuery(this).attr('data-author-id') );
-									break;
-							}
-						}
-					});
-					sounds.open.play();
-					break;
-
-				default:
-					do_redmond_error_window( redmond_terms.ajaxerror );
-					console.log('Unknown Error');
-					break;
+			var data = redmondParseAjaxResponse( returned );
+			if ( false === data ) {
+				redmondHandleAjaxError();
+				return;
 			}
+			if( typeof( targetId ) !== 'undefined' && jQuery("#" + targetId ).length > 0 ) {
+				jQuery("#"+targetId).dialog('close');
+			}
+			redmond_window( data.taskname , data.title , data.html , data.menu , true, true , data.icon );
+			jQuery("#" + data.taskname).find('a').on('click',function(e) {
+				if( typeof( jQuery(this).attr('id') ) === 'undefined' && typeof( jQuery(this).attr('data-type') ) !== 'undefined' ) {
+					e.preventDefault();
+					switch( jQuery(this).attr('data-type') ) {
+					case 'regular':
+						open_this_as_redmond_dialog(this);
+						break;
+
+					default:
+						open_redmond_authors_window( jQuery(this).attr('data-author-id') );
+						break;
+					}
+				}
+			});
+			sounds.open.play();
 		}
 	});
 }
@@ -393,65 +349,73 @@ function open_redmond_search_window( search ) {
 		data: {
 			action: 'getsearch',
 			search:search,
+			nonce: redmond_terms.nonce,
 		},
 		async: true,
 		beforeSend: function() {},
 		cache: false,
 		crossDomain: false,
-		error: function() {
-			do_redmond_error_window( redmond_terms.ajaxerror );
-			console.log('AJAX Error');
+		dataType: 'json',
+		error: function( jqXHR ) {
+			redmondHandleAjaxError( jqXHR );
 		},
 		method: 'POST',
 		success: function( returned ) {
-			var res = wpAjax.parseAjaxResponse( returned );
-			switch(true) {
-				case ( res === false ):
-					do_redmond_error_window( redmond_terms.ajaxerror );
-					console.log('No such AJAX Action');
-					break;
-
-				case ( typeof( res.responses ) == 'undefined' ):
-					do_redmond_error_window( redmond_terms.ajaxerror );
-					console.log('No Parsable Response');
-					break;
-
-				case ( res.responses.length > 0 ):
-					var data = jQuery.parseJSON( res.responses[0].data );
-					redmond_window( 'searchwindow' , windowTitle , data.html , redmond_terms.default_file_menu , false , true , redmond_terms.searchIcon );
-					jQuery("#searchwindow").find('button').on('click',function(e) {
-						e.preventDefault();
-						open_redmond_search_window( jQuery('#searchwindow').find('input').val() );
-					});
-					jQuery("#searchwindow").find('input').on('keyup',function(e){
-						if( e.keyCode == 13 ) {
-							open_redmond_search_window( jQuery('#searchwindow').find('input').val() );	
-						}
-					});
-					jQuery("#searchwindow").find('a').on('click',function(e) {
-						if( typeof( jQuery(this).attr('id') ) === 'undefined' && typeof( jQuery(this).attr('data-type') ) !== 'undefined' ) {
-							e.preventDefault();
-							switch( jQuery(this).attr('data-type') ) {
-								case 'regular':
-									open_this_as_redmond_dialog(this);
-									break;
-
-								default:
-									open_category_as_redmond_dialog(this);
-									break;
-							}
-						}
-					});
-					sounds.open.play();
-					break;
-
-				default:
-					do_redmond_error_window( redmond_terms.ajaxerror );
-					console.log('Unknown Error');
-					break;
+			var data = redmondParseAjaxResponse( returned );
+			if ( false === data ) {
+				redmondHandleAjaxError();
+				return;
 			}
+			redmond_window( 'searchwindow' , windowTitle , data.html , redmond_terms.default_file_menu , false , true , redmond_terms.searchIcon );
+			jQuery("#searchwindow").find('button').on('click',function(e) {
+				e.preventDefault();
+				open_redmond_search_window( jQuery('#searchwindow').find('input').val() );
+			});
+			jQuery("#searchwindow").find('input').on('keyup',function(e){
+				if( e.keyCode == 13 ) {
+					open_redmond_search_window( jQuery('#searchwindow').find('input').val() );
+				}
+			});
+			jQuery("#searchwindow").find('a').on('click',function(e) {
+				if( typeof( jQuery(this).attr('id') ) === 'undefined' && typeof( jQuery(this).attr('data-type') ) !== 'undefined' ) {
+					e.preventDefault();
+					switch( jQuery(this).attr('data-type') ) {
+					case 'regular':
+						open_this_as_redmond_dialog(this);
+						break;
+
+					default:
+						open_category_as_redmond_dialog(this);
+						break;
+					}
+				}
+			});
+			sounds.open.play();
 		}
 	});
+}
+
+function redmondHandleAjaxError( jqXHR ) {
+	var message = redmond_terms.ajaxerror;
+	if ( jqXHR && jqXHR.responseJSON && jqXHR.responseJSON.data ) {
+		if ( typeof jqXHR.responseJSON.data === 'string' && jqXHR.responseJSON.data.length > 0 ) {
+			message = jqXHR.responseJSON.data;
+		} else if ( jqXHR.responseJSON.data.message ) {
+			message = jqXHR.responseJSON.data.message;
+		}
+	}
+	do_redmond_error_window( message );
+	console.log( 'AJAX Error', jqXHR );
+}
+
+function redmondParseAjaxResponse( returned ) {
+	if ( ! returned || typeof returned.success === 'undefined' ) {
+		return false;
+	}
+	if ( true !== returned.success || typeof returned.data === 'undefined' ) {
+		return false;
+	}
+	return returned.data;
 }
 
 function do_redmond_error_window( message ) {

--- a/functions.php
+++ b/functions.php
@@ -4,6 +4,11 @@ define( 'REDMONDBASE', __DIR__ );
 define( 'RTEXTDOMAIN', 'redmond-inspired' );
 define( 'REDMONDURI', get_template_directory_uri() );
 
+if ( ! defined( 'REDMOND_THEME_VERSION' ) ) {
+	define( 'REDMOND_THEME_VERSION', '1.0.0' );
+}
+
+
 function redmond_nr_function( $function, $data = null ) {
 	if ( extension_loaded( 'newrelic' ) && substr( $function, 0 , 9 ) == 'newrelic_' ) {
 		switch ( true ) {
@@ -32,9 +37,10 @@ function redmond_wp_print_r( $ar, $print = false ) {
 	}
 }
 
-if ( extension_loaded( 'newrelic' ) && get_option( 'redmond_use_newrelic_error_logger', false ) == true ) {
+if ( extension_loaded( 'newrelic' ) && true === get_option( 'redmond_use_newrelic_error_logger', false ) ) {
 	set_error_handler( 'newrelic_notice_error' );
 }
+
 
 $objects = new RecursiveIteratorIterator( new RecursiveDirectoryIterator( REDMONDBASE . '/bin' ), RecursiveIteratorIterator::SELF_FIRST );
 foreach ( $objects as $name => $obj ) {
@@ -46,16 +52,18 @@ foreach ( $objects as $name => $obj ) {
 /**
  * Add and Remove Actions Directly from the Functions Page
  */
-add_action( 'after_setup_theme','redmond_remove_admin_bar' );
-add_action( 'after_setup_theme','redmond_add_theme_supports' );
-add_action( 'customize_register','redmond_customize_register' );
-add_action( 'init','redmond_add_menus' );
-add_action( 'wp_enqueue_scripts','redmond_theme_add_scripts_and_styles' );
-add_filter( 'wp_title','redmond_filter_wp_title',1000,2 );
-add_action( 'wp_head','redmond_do_site_icons' );
-add_action( 'wp_head','redmond_add_custom_start_menu_styles' );
-add_action( 'wp_head','redmond_new_relic_timing_header' );
-add_action( 'wp_footer','redmond_new_relic_timing_footer' );
+add_action( 'after_setup_theme', 'redmond_remove_admin_bar' );
+add_action( 'after_setup_theme', 'redmond_add_theme_supports' );
+add_action( 'customize_register', 'redmond_customize_register' );
+add_action( 'after_setup_theme', 'redmond_add_menus' );
+add_action( 'wp_enqueue_scripts', 'redmond_theme_add_scripts_and_styles' );
+add_action( 'wp_head', 'redmond_do_site_icons' );
+add_action( 'wp_head', 'redmond_add_custom_start_menu_styles' );
+if ( extension_loaded( 'newrelic' ) ) {
+	add_action( 'wp_head', 'redmond_new_relic_timing_header' );
+	add_action( 'wp_footer', 'redmond_new_relic_timing_footer' );
+}
+
 add_action( 'wp_ajax_getpost','redmond_getpost_callback' );
 add_action( 'wp_ajax_nopriv_getpost','redmond_getpost_callback' );
 add_action( 'wp_ajax_getarchive','redmond_getarchive_callback' );
@@ -65,24 +73,21 @@ add_action( 'wp_ajax_nopriv_getsearch','redmond_getsearch_callback' );
 add_action( 'wp_ajax_getauthor','redmond_getauthor_callback' );
 add_action( 'wp_ajax_nopriv_getauthor','redmond_getauthor_callback' );
 add_action( 'wp_footer','redmond_set_info_cookies' );
-remove_action( 'wp_head', 'feed_links_extra' );
-remove_action( 'wp_head', 'feed_links' );
-remove_action( 'wp_head', 'rsd_link' );
-remove_action( 'wp_head', 'wlwmanifest_link' );
-remove_action( 'wp_head', 'index_rel_link' );
-remove_action( 'wp_head', 'parent_post_rel_link' );
-remove_action( 'wp_head', 'start_post_rel_link' );
-remove_action( 'wp_head', 'adjacent_posts_rel_link' );
-remove_action( 'wp_head', 'wp_generator' );
-remove_action( 'wp_head', 'index_rel_link' );
-remove_action( 'wp_head', 'feed_links' );
-remove_action( 'wp_head', 'feed_links_extra', 3 );
-remove_action( 'wp_head', 'feed_links', 2 );
-remove_action( 'wp_head', 'rsd_link' );
-remove_action( 'wp_head', 'wlwmanifest_link' );
-remove_action( 'wp_head', 'index_rel_link' );
-remove_action( 'wp_head', 'parent_post_rel_link', 10, 0 );
-remove_action( 'wp_head', 'start_post_rel_link', 10, 0 );
-remove_action( 'wp_head', 'adjacent_posts_rel_link', 10, 0 );
-remove_action( 'wp_head', 'wp_generator' );
+
+$redmond_head_cleanup = array(
+	'rsd_link',
+	'wlwmanifest_link',
+	'index_rel_link',
+	'parent_post_rel_link',
+	'parent_post_rel_link_wp_head',
+	'start_post_rel_link',
+	'start_post_rel_link_wp_head',
+	'adjacent_posts_rel_link_wp_head',
+	'wp_generator',
+);
+
+foreach ( $redmond_head_cleanup as $redmond_head_action ) {
+	remove_action( 'wp_head', $redmond_head_action );
+}
+
 ?>

--- a/header.php
+++ b/header.php
@@ -1,20 +1,16 @@
 <?php
-	defined( 'ABSPATH' ) || die( 'Sorry, but you cannot access this page directly.' );
-	global $current_user, $wpdb;
-	$quick_launch = redmond_get_menu_as_array( 'quick_launch' );
-	get_currentuserinfo();
+defined( 'ABSPATH' ) || die( 'Sorry, but you cannot access this page directly.' );
+global $wpdb;
+$quick_launch  = redmond_get_menu_as_array( 'quick_launch' );
+$current_user = wp_get_current_user();
 ?>
 <!DOCTYPE html>
 <html <?php language_attributes(); ?>>
 	<head>
 		<meta charset="<?php bloginfo( 'charset' ); ?>">
-		<meta name="viewport" content="width=device-width">
-		<title><?php wp_title( '', true, 'right' ); ?> | <?php print esc_html( get_bloginfo( 'name' ) ); ?></title>
+		<meta name="viewport" content="width=device-width, initial-scale=1">
 		<link rel="profile" href="http://gmpg.org/xfn/11">
-		<meta name="viewport" content="width=device-width, initial-scale=1.0">
-		<meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=no">
 		<meta http-equiv="X-UA-Compatible" content="chrome=1">
-		<meta http-equiv="Content-Type" content="text/html; charset=UTF-8">
 		<meta name="apple-mobile-web-app-capable" content="yes" />
 		<meta name="apple-mobile-web-app-status-bar-style" content="black">
 		<meta name="format-detection" content="telephone=no">
@@ -23,6 +19,11 @@
 		?>
 	</head>
 	<body <?php body_class( 'custom-background' ); ?>>
+		<?php
+		if ( function_exists( 'wp_body_open' ) ) {
+			wp_body_open();
+		}
+		?>
 		<div id="taskbar-outer">
 			<div id="taskbar-inner">
 				<span class="button-outer">

--- a/resources/editor-style.css
+++ b/resources/editor-style.css
@@ -1,0 +1,20 @@
+/* Editor styles for the Redmond Inspired theme */
+body.wp-block-editor {
+	font-family: Tahoma, Verdana, Segoe, sans-serif;
+	background-color: #3a6ea5;
+	color: #000;
+}
+
+body.wp-block-editor .editor-styles-wrapper {
+	font-family: inherit;
+	background-image: url('../resources/startbg.png');
+	background-size: cover;
+}
+
+body.wp-block-editor .wp-block {
+	max-width: 700px;
+}
+
+body.wp-block-editor a {
+	color: #0b58a2;
+}

--- a/style.css
+++ b/style.css
@@ -1,8 +1,8 @@
 /*
 Theme Name:         Redmond Inspired
 Theme URI:          https://jak.guru
-Description:        Wordpress Theme inspired by classic Windows Operating Systems
-Version:            0.0.1
+Description:        WordPress theme inspired by classic Windows Operating Systems
+Version:            1.0.0
 Author:             Jak Gurudiv.file-bar
 Author URI:         https://jak.guru
 


### PR DESCRIPTION
## Summary
- update theme constants, head cleanup, and support declarations for modern WordPress features
- refresh asset enqueues, add a block-editor stylesheet, and upgrade bundled script versions
- secure AJAX endpoints with nonce checks, JSON responses, and matching front-end handling

## Testing
- php -l bin/ajax.php
- php -l bin/client.php
- php -l functions.php
- php -l header.php

------
https://chatgpt.com/codex/tasks/task_b_68dec515986c8329bd03041bf36439e4