### PR TITLE
Fix popup dialog scrolling and close button styling

### DIFF
--- a/resources/redmond-dialogs.js
+++ b/resources/redmond-dialogs.js
@@ -51,12 +51,14 @@ function redmond_window( objid , title , content , filecommands , canResize , dr
 			},
 			open: function( event, ui ) {
 				processes[objid].find('div.file-bar>ul').append(redmond_filecommands_to_html(filecommands));
-				processes[objid].parent().find('.ui-dialog-titlebar>span').css({
-					'background-image': 'url(' + icon + ')',
-					'background-repeat': 'no-repeat',
-					'background-size': 'contain',
-				});
-                                processes[objid].parent().find('button.ui-dialog-titlebar-close')
+                                processes[objid].parent().find('.ui-dialog-titlebar>span').css({
+                                        'background-image': 'url(' + icon + ')',
+                                        'background-repeat': 'no-repeat',
+                                        'background-size': 'contain',
+                                });
+                                var closeButton = processes[objid].parent().find('button.ui-dialog-titlebar-close');
+                                redmond_style_close_button(closeButton);
+                                closeButton
                                         .off('click.redmondClose')
                                         .on('click.redmondClose', function(e){
                                                 e.preventDefault();
@@ -97,7 +99,9 @@ function redmond_window( objid , title , content , filecommands , canResize , dr
                         'background-repeat': 'no-repeat',
                         'background-size': 'contain',
                 });
-                processes[objid].parent().find('button.ui-dialog-titlebar-close')
+                var closeButton = processes[objid].parent().find('button.ui-dialog-titlebar-close');
+                redmond_style_close_button(closeButton);
+                closeButton
                         .off('click.redmondClose')
                         .on('click.redmondClose', function(e){
                                 e.preventDefault();
@@ -139,18 +143,30 @@ function redmond_window( objid , title , content , filecommands , canResize , dr
                 }
 
                 dialogWrapper.css({
-                        'padding-bottom': dialogWrapper.outerHeight() > maxWindowHeight ? 20 : '',
+                        'height': '',
+                        'padding-bottom': '',
                         'max-height': maxWindowHeight,
-                        'overflow-y': 'auto',
                         'overflow-x': 'visible'
                 });
 
+                var wrapperNeedsScroll = dialogWrapper.outerHeight() > maxWindowHeight;
+
+                dialogWrapper.css({
+                        'padding-bottom': wrapperNeedsScroll ? 20 : '',
+                        'overflow-y': wrapperNeedsScroll ? 'auto' : 'visible',
+                        'height': wrapperNeedsScroll ? maxWindowHeight : ''
+                });
+
                 contentArea.css({
+                        'height': '',
                         'max-height': maxContentHeight,
                         'overflow-y': 'auto',
-                        'overflow-x': 'auto',
-                        'height': ''
+                        'overflow-x': 'auto'
                 });
+
+                if ( contentArea.outerHeight() > maxContentHeight ) {
+                        contentArea.css('height', maxContentHeight);
+                }
         });
 }
 
@@ -167,6 +183,24 @@ function redmond_filecommands_to_html( filecommands ) {
 	html += '	</ul>' + "\r\n";
 	html += '</li>' + "\r\n";
 	return html;
+}
+
+function redmond_style_close_button( closeButton ) {
+        if ( ! closeButton || ! closeButton.length ) {
+                return;
+        }
+
+        var closeLabel = ( window.redmond_terms && redmond_terms.close ) ? redmond_terms.close : 'Close';
+
+        closeButton
+                .removeClass('ui-button-icon-only')
+                .addClass('redmond-close-button')
+                .attr('title', closeLabel)
+                .attr('aria-label', closeLabel);
+
+        closeButton.find('span.ui-icon').remove();
+        closeButton.find('span.redmond-close-text').remove();
+        closeButton.append('<span class="redmond-close-text" aria-hidden="true">&times;</span>');
 }
 
 function redmond_close_this( obj ) {

--- a/style.css
+++ b/style.css
@@ -464,24 +464,43 @@ div.redmond-dialog-window>.ui-dialog-titlebar>span {
 }
 
 div.redmond-dialog-window>.ui-dialog-titlebar>button {
-	position: absolute;
-	top: 1px;
-	right: 1px;
-	background: var(--redmond-surface);
-	background-color: var(--redmond-surface);
-	min-height: 20px;
-	border: solid 1px;
-	border-top-color: var(--redmond-border-highlight);
-	border-left-color: var(--redmond-border-highlight);
-	border-right-color: var(--redmond-border-dark);
-	border-bottom-color: var(--redmond-border-dark);
-	display: inline-block;
-	padding: 0;
-	line-height: 0;
-	height: auto;
-	width: 20px;
-	font-weight: 700;
-	color: var(--redmond-text);
+        position: absolute;
+        top: 1px;
+        right: 1px;
+        background: var(--redmond-surface);
+        background-color: var(--redmond-surface);
+        min-height: 20px;
+        border: solid 1px;
+        border-top-color: var(--redmond-border-highlight);
+        border-left-color: var(--redmond-border-highlight);
+        border-right-color: var(--redmond-border-dark);
+        border-bottom-color: var(--redmond-border-dark);
+        display: inline-block;
+        padding: 0;
+        line-height: 1;
+        height: auto;
+        width: 22px;
+        font-weight: 700;
+        color: var(--redmond-text);
+}
+
+div.redmond-dialog-window>.ui-dialog-titlebar>button.redmond-close-button {
+        display: flex;
+        align-items: center;
+        justify-content: center;
+        font-size: 16px;
+        padding: 0;
+}
+
+div.redmond-dialog-window>.ui-dialog-titlebar>button.redmond-close-button .redmond-close-text {
+        line-height: 1;
+        font-size: 16px;
+        display: block;
+}
+
+div.redmond-dialog-window>.ui-dialog-titlebar>button.redmond-close-button:focus-visible {
+        outline: 2px solid var(--redmond-accent);
+        outline-offset: 1px;
 }
 
 div.redmond-dialog-window>div.ui-dialog-content {


### PR DESCRIPTION
## Summary
- ensure dialog windows recalculate their height limits so long content scrolls inside the popup instead of overflowing
- normalize the close button markup and styling for better visibility and accessibility

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_690fa6ee89c8832a842139bf4060478b)