### PR TITLE
Fix dialog layout sizing and hide behavior

### DIFF
--- a/functions.js
+++ b/functions.js
@@ -35,50 +35,53 @@ jQuery(function() {
 	if( redmond_terms.playLoginSounds ) {
 		sounds.login.play();
 	}
-	for( var process in processes ) {
-		processes[process].dialog('moveToTop');
-		find_window_on_top();
-		break;
-	}
-	jQuery(window).on('resize',function() {
-		jQuery("div.redmond-dialog-window").each(function() {
-		var obj = this;
-                jQuery(this).css({
-                        'padding-bottom': function() {
-                                if ( jQuery(obj).height() > ( jQuery(window).height() * 0.9 ) ) {
-                                        return 20;
-                                }
-                                else {
-                                        0;
-                                }
-                        },
-                        height: function() {
-                                if ( jQuery(obj).height() > ( jQuery(window).height() * 0.9 ) ) {
-                                        return ( jQuery(window).height() * 0.9 )
-                                }
-                        },
-                        'overflow': 'visible',
-                });
-        });
+        for( var process in processes ) {
+                if ( ! Object.prototype.hasOwnProperty.call(processes, process) ) {
+                        continue;
+                }
+
+                if ( typeof processes[process].dialog === 'function' && processes[process].dialog('isOpen') ) {
+                        processes[process].dialog('moveToTop');
+                        find_window_on_top();
+                        break;
+                }
+        }
+
+        if ( typeof redmond_adjust_dialog_sizes === 'function' ) {
+                redmond_adjust_dialog_sizes();
+        }
+
+        jQuery(window).on('resize',function() {
+                if ( typeof redmond_adjust_dialog_sizes === 'function' ) {
+                        redmond_adjust_dialog_sizes();
+                }
         });
 });
 
 function checkOpenWindows() {
-	processList = '';
-	for( var process in processes ) {
-		if( parseInt(processes[process].parent().css('top'),10) >= 0 ) {
-			processes[process].currentTop = parseInt(processes[process].parent().css('top'),10);
-		}
-		else {
-			processes[process].parent().css('top',processes[process].currentTop);
-		}
-		processList += '<li onclick="processes[\'' +process+ '\'].dialog(\'moveToTop\')" id="' +process+ '_taskbar">';
-		processList += '<span class="task-icon"';
-		processList += ' style="' + processes[process].parent().find('.ui-dialog-title').attr('style') + '"';
-		processList += '></span>';
-		processList += processes[process].parent().find('.ui-dialog-title').html().substring(0,20) + '</li>' + "\r\n";
-	}
-	jQuery("#open-processes").html( processList );
+        processList = '';
+        for( var process in processes ) {
+                if ( ! Object.prototype.hasOwnProperty.call(processes, process) ) {
+                        continue;
+                }
+
+                if ( typeof processes[process].dialog !== 'function' || ! processes[process].dialog('isOpen') ) {
+                        continue;
+                }
+
+                if( parseInt(processes[process].parent().css('top'),10) >= 0 ) {
+                        processes[process].currentTop = parseInt(processes[process].parent().css('top'),10);
+                }
+                else {
+                        processes[process].parent().css('top',processes[process].currentTop);
+                }
+                processList += '<li onclick="processes[\'' +process+ '\'].dialog(\'moveToTop\')" id="' +process+ '_taskbar">';
+                processList += '<span class="task-icon"';
+                processList += ' style="' + processes[process].parent().find('.ui-dialog-title').attr('style') + '"';
+                processList += '></span>';
+                processList += processes[process].parent().find('.ui-dialog-title').html().substring(0,20) + '</li>' + "\r\n";
+        }
+        jQuery("#open-processes").html( processList );
 	jQuery("#open-processes>li").on('click',function() {
 		find_window_on_top();
 	});
@@ -87,20 +90,34 @@ function checkOpenWindows() {
 
 function find_window_on_top() {
 	var top;
-	var hightestZ = 0;
-	for( var process in processes ) {
-		if( processes[process].zIndex() > hightestZ ) {
-			top = process;
-			hightestZ = processes[process].zIndex();
-		}
-		var currTop = processes[process].parent().offset().top;
-		if( currTop < 0 ) {
-			processes[process].parent().offset({top: 100, left: processes[process].parent().offset().left});
-		}
-	}
-	var taskbar = jQuery("#" + top + '_taskbar');
-	jQuery("#open-processes>li").removeClass('active');
-	taskbar.addClass('active');
+        var hightestZ = -Infinity;
+        for( var process in processes ) {
+                if ( ! Object.prototype.hasOwnProperty.call(processes, process) ) {
+                        continue;
+                }
+
+                if ( typeof processes[process].dialog !== 'function' || ! processes[process].dialog('isOpen') ) {
+                        continue;
+                }
+
+                if( processes[process].zIndex() > hightestZ ) {
+                        top = process;
+                        hightestZ = processes[process].zIndex();
+                }
+                var currTop = processes[process].parent().offset().top;
+                if( currTop < 0 ) {
+                        processes[process].parent().offset({top: 100, left: processes[process].parent().offset().left});
+                }
+        }
+
+        jQuery("#open-processes>li").removeClass('active');
+
+        if ( typeof top === 'undefined' ) {
+                return;
+        }
+
+        var taskbar = jQuery("#" + top + '_taskbar');
+        taskbar.addClass('active');
 }
 
 function startSystemClock() {

--- a/resources/redmond-dialogs.js
+++ b/resources/redmond-dialogs.js
@@ -39,24 +39,27 @@ function redmond_window( objid , title , content , filecommands , canResize , dr
                         draggable: draggable,
                         resizable: canResize,
                         position: {
-                                my: 'center',
-                                at: 'center',
+                                my: 'center top',
+                                at: 'center top+40',
                                 of: workspaceTarget,
                                 collision: 'fit'
                         },
                         close: function( event, ui ) {
-                                processes[objid].remove();
-                                delete processes[objid];
-				jQuery(window).trigger('checkOpenWindows');
-			},
-			open: function( event, ui ) {
-				processes[objid].find('div.file-bar>ul').append(redmond_filecommands_to_html(filecommands));
-				processes[objid].parent().find('.ui-dialog-titlebar>span').css({
-					'background-image': 'url(' + icon + ')',
-					'background-repeat': 'no-repeat',
-					'background-size': 'contain',
-				});
-                                processes[objid].parent().find('button.ui-dialog-titlebar-close')
+                                processes[objid].parent().addClass('redmond-dialog-hidden');
+                                jQuery(window).trigger('checkOpenWindows');
+                        },
+                        open: function( event, ui ) {
+                                processes[objid].find('div.file-bar>ul').append(redmond_filecommands_to_html(filecommands));
+                                processes[objid].parent().find('.ui-dialog-titlebar>span').css({
+                                        'background-image': 'url(' + icon + ')',
+                                        'background-repeat': 'no-repeat',
+                                        'background-size': 'contain',
+                                });
+                                processes[objid].parent().removeClass('redmond-dialog-hidden');
+
+                                var closeButton = processes[objid].parent().find('button.ui-dialog-titlebar-close');
+                                redmond_style_close_button(closeButton);
+                                closeButton
                                         .off('click.redmondClose')
                                         .on('click.redmondClose', function(e){
                                                 e.preventDefault();
@@ -77,14 +80,16 @@ function redmond_window( objid , title , content , filecommands , canResize , dr
 						var fullwidth = parseInt( processes[objid].find('span.dialog-close-button').parent().css('width') , 10 );
 						return ( fullwidth / 2 ) - ( parseInt( processes[objid].find('span.dialog-close-button').css('width') , 10 ) / 2 ) - 10;
 					}
-				});
-			},
-			focus: function( event, ui ) {
-				processes[objid].find('div.file-bar').zIndex(processes[objid].zIndex());
-				find_window_on_top();
-			},
+                                });
+
+                                redmond_adjust_dialog_sizes();
+                        },
+                        focus: function( event, ui ) {
+                                processes[objid].find('div.file-bar').zIndex(processes[objid].zIndex());
+                                find_window_on_top();
+                        },
 			title: title,
-			closeText: "\u00d7",
+			closeText: '',
 			width: 'auto',
 			height: 'auto',
 		});
@@ -92,12 +97,15 @@ function redmond_window( objid , title , content , filecommands , canResize , dr
 	else {
 		processes[objid].html('<div class="file-bar"><ul></ul></div>' + content + '</div>');
                 processes[objid].find('div.file-bar>ul').append(redmond_filecommands_to_html(filecommands));
+                processes[objid].parent().removeClass('redmond-dialog-hidden');
                 processes[objid].parent().find('.ui-dialog-titlebar>span').css({
                         'background-image': 'url(' + icon + ')',
                         'background-repeat': 'no-repeat',
                         'background-size': 'contain',
                 });
-                processes[objid].parent().find('button.ui-dialog-titlebar-close')
+                var closeButton = processes[objid].parent().find('button.ui-dialog-titlebar-close');
+                redmond_style_close_button(closeButton);
+                closeButton
                         .off('click.redmondClose')
                         .on('click.redmondClose', function(e){
                                 e.preventDefault();
@@ -115,43 +123,18 @@ function redmond_window( objid , title , content , filecommands , canResize , dr
 				return ( fullwidth / 2 ) - ( parseInt( processes[objid].find('span.dialog-close-button').css('width') , 10 ) / 2 ) - 10;
 			}
 		});
+                processes[objid].dialog('open');
                 processes[objid].dialog('moveToTop');
                 processes[objid].dialog('option', 'appendTo', workspaceTarget);
                 processes[objid].dialog('option', 'position', {
-                        my: 'center',
-                        at: 'center',
+                        my: 'center top',
+                        at: 'center top+40',
                         of: workspaceTarget,
                         collision: 'fit'
                 });
                 find_window_on_top();
         }
-        jQuery("div.redmond-dialog-window").each(function() {
-                var dialogWrapper = jQuery(this);
-                var workspace = jQuery('#desktop-window-area');
-                var viewportHeight = workspace.length ? workspace.innerHeight() : jQuery(window).height();
-                var maxWindowHeight = Math.floor(viewportHeight * 0.9);
-                var titleBarHeight = dialogWrapper.children('.ui-dialog-titlebar').outerHeight(true) || 0;
-                var contentArea = dialogWrapper.children('.ui-dialog-content');
-                var maxContentHeight = maxWindowHeight - titleBarHeight;
-
-                if ( maxContentHeight < 120 ) {
-                        maxContentHeight = Math.max(viewportHeight - titleBarHeight - 20, 120);
-                }
-
-                dialogWrapper.css({
-                        'padding-bottom': dialogWrapper.outerHeight() > maxWindowHeight ? 20 : '',
-                        'max-height': maxWindowHeight,
-                        'overflow-y': 'auto',
-                        'overflow-x': 'visible'
-                });
-
-                contentArea.css({
-                        'max-height': maxContentHeight,
-                        'overflow-y': 'auto',
-                        'overflow-x': 'auto',
-                        'height': ''
-                });
-        });
+        redmond_adjust_dialog_sizes();
 }
 
 function redmond_filecommands_to_html( filecommands ) {
@@ -167,6 +150,75 @@ function redmond_filecommands_to_html( filecommands ) {
 	html += '	</ul>' + "\r\n";
 	html += '</li>' + "\r\n";
 	return html;
+}
+
+function redmond_style_close_button( closeButton ) {
+        if ( ! closeButton || ! closeButton.length ) {
+                return;
+        }
+
+        var closeLabel = ( window.redmond_terms && redmond_terms.close ) ? redmond_terms.close : 'Close';
+
+        closeButton
+                .removeClass('ui-button-icon-only')
+                .addClass('redmond-close-button')
+                .attr('title', closeLabel)
+                .attr('aria-label', closeLabel);
+
+        closeButton.find('span.ui-icon').remove();
+        closeButton.find('span.ui-button-icon-space').remove();
+        closeButton
+                .contents()
+                .filter(function(){
+                        return this.nodeType === 3;
+                })
+                .remove();
+        closeButton.find('span.redmond-close-text').remove();
+        closeButton.append('<span class="redmond-close-text" aria-hidden="true">&times;</span>');
+}
+
+function redmond_adjust_dialog_sizes() {
+        var workspace = jQuery('#desktop-window-area');
+        var viewportHeight = workspace.length ? workspace.innerHeight() : jQuery(window).height();
+        var minWindowHeight = 200;
+        var verticalBuffer = 60;
+        var maxWindowHeight = Math.max(viewportHeight - verticalBuffer, Math.min(viewportHeight, minWindowHeight));
+        var targetWindowHeight = Math.min(Math.max(Math.floor(viewportHeight * 0.5), minWindowHeight), maxWindowHeight);
+        var positionTarget = workspace.length ? workspace : jQuery(window);
+
+        jQuery('div.redmond-dialog-window').each(function() {
+                var dialogWrapper = jQuery(this);
+                var titleBar = dialogWrapper.children('.ui-dialog-titlebar');
+                var contentArea = dialogWrapper.children('.ui-dialog-content');
+                var titleBarHeight = titleBar.outerHeight(true) || 0;
+                var contentHeight = Math.max(targetWindowHeight - titleBarHeight, 120);
+
+                dialogWrapper.css({
+                        'height': targetWindowHeight,
+                        'max-height': maxWindowHeight,
+                        'overflow-y': 'auto',
+                        'overflow-x': 'visible',
+                        'padding-bottom': ''
+                });
+
+                contentArea.css({
+                        'height': contentHeight,
+                        'max-height': contentHeight,
+                        'overflow-y': 'auto',
+                        'overflow-x': 'auto'
+                });
+
+                var dialogInstance = contentArea.data('ui-dialog') || contentArea.data('dialog');
+
+                if ( dialogInstance ) {
+                        contentArea.dialog('option', 'position', {
+                                my: 'center top',
+                                at: 'center top+40',
+                                of: positionTarget,
+                                collision: 'fit'
+                        });
+                }
+        });
 }
 
 function redmond_close_this( obj ) {

--- a/style.css
+++ b/style.css
@@ -416,24 +416,28 @@ ul.archives-inner-wrapper>li:hover, ul.archives-inner-wrapper>li:focus, ul.archi
 }
 
 div.redmond-dialog-window {
-	z-index: 500;
-	background: var(--redmond-surface-alt);
-	background-color: var(--redmond-surface-alt);
-	min-height: 20px;
-	border: solid 1px;
-	border-top-color: var(--redmond-border-highlight);
-	border-left-color: var(--redmond-border-highlight);
-	border-right-color: var(--redmond-border-dark);
-	border-bottom-color: var(--redmond-border-dark);
-	display: inline-block;
-	max-width: 100%;
-	max-height: 100%;
-	position: absolute !important;
+        z-index: 500;
+        background: var(--redmond-surface-alt);
+        background-color: var(--redmond-surface-alt);
+        min-height: 20px;
+        border: solid 1px;
+        border-top-color: var(--redmond-border-highlight);
+        border-left-color: var(--redmond-border-highlight);
+        border-right-color: var(--redmond-border-dark);
+        border-bottom-color: var(--redmond-border-dark);
+        display: inline-block;
+        max-width: 100%;
+        max-height: 100%;
+        position: absolute !important;
+}
+
+div.redmond-dialog-window.redmond-dialog-hidden {
+        display: none !important;
 }
 
 div.redmond-dialog-window>.ui-dialog-content, div.redmond-dialog-window>.ui-dialog-titlebar {
-	min-width: 300px;
-	display: block;
+        min-width: 300px;
+        display: block;
 }
 
 div.redmond-dialog-window>.ui-dialog-content {
@@ -464,24 +468,43 @@ div.redmond-dialog-window>.ui-dialog-titlebar>span {
 }
 
 div.redmond-dialog-window>.ui-dialog-titlebar>button {
-	position: absolute;
-	top: 1px;
-	right: 1px;
-	background: var(--redmond-surface);
-	background-color: var(--redmond-surface);
-	min-height: 20px;
-	border: solid 1px;
-	border-top-color: var(--redmond-border-highlight);
-	border-left-color: var(--redmond-border-highlight);
-	border-right-color: var(--redmond-border-dark);
-	border-bottom-color: var(--redmond-border-dark);
-	display: inline-block;
-	padding: 0;
-	line-height: 0;
-	height: auto;
-	width: 20px;
-	font-weight: 700;
-	color: var(--redmond-text);
+        position: absolute;
+        top: 1px;
+        right: 1px;
+        background: var(--redmond-surface);
+        background-color: var(--redmond-surface);
+        min-height: 20px;
+        border: solid 1px;
+        border-top-color: var(--redmond-border-highlight);
+        border-left-color: var(--redmond-border-highlight);
+        border-right-color: var(--redmond-border-dark);
+        border-bottom-color: var(--redmond-border-dark);
+        display: inline-block;
+        padding: 0;
+        line-height: 1;
+        height: auto;
+        width: 22px;
+        font-weight: 700;
+        color: var(--redmond-text);
+}
+
+div.redmond-dialog-window>.ui-dialog-titlebar>button.redmond-close-button {
+        display: flex;
+        align-items: center;
+        justify-content: center;
+        font-size: 16px;
+        padding: 0;
+}
+
+div.redmond-dialog-window>.ui-dialog-titlebar>button.redmond-close-button .redmond-close-text {
+        line-height: 1;
+        font-size: 16px;
+        display: block;
+}
+
+div.redmond-dialog-window>.ui-dialog-titlebar>button.redmond-close-button:focus-visible {
+        outline: 2px solid var(--redmond-accent);
+        outline-offset: 1px;
 }
 
 div.redmond-dialog-window>div.ui-dialog-content {


### PR DESCRIPTION
## Summary
- align dialogs to the top of the workspace, reuse a shared sizing helper, and lock their height to half the viewport with scrolling
- update dialog close handling to hide the widget instead of removing it while keeping taskbar state in sync
- add a hidden dialog utility class and route resize events through the new sizing helper

## Testing
- not run (not requested)

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_690fa6ee89c8832a842139bf4060478b)