### PR TITLE
Stabilize dialog sizing and reopen handling

### DIFF
--- a/functions.js
+++ b/functions.js
@@ -35,50 +35,53 @@ jQuery(function() {
 	if( redmond_terms.playLoginSounds ) {
 		sounds.login.play();
 	}
-	for( var process in processes ) {
-		processes[process].dialog('moveToTop');
-		find_window_on_top();
-		break;
-	}
-	jQuery(window).on('resize',function() {
-		jQuery("div.redmond-dialog-window").each(function() {
-		var obj = this;
-                jQuery(this).css({
-                        'padding-bottom': function() {
-                                if ( jQuery(obj).height() > ( jQuery(window).height() * 0.9 ) ) {
-                                        return 20;
-                                }
-                                else {
-                                        0;
-                                }
-                        },
-                        height: function() {
-                                if ( jQuery(obj).height() > ( jQuery(window).height() * 0.9 ) ) {
-                                        return ( jQuery(window).height() * 0.9 )
-                                }
-                        },
-                        'overflow': 'visible',
-                });
-        });
+        for( var process in processes ) {
+                if ( ! Object.prototype.hasOwnProperty.call(processes, process) ) {
+                        continue;
+                }
+
+                if ( typeof processes[process].dialog === 'function' && processes[process].dialog('isOpen') ) {
+                        processes[process].dialog('moveToTop');
+                        find_window_on_top();
+                        break;
+                }
+        }
+
+        if ( typeof redmond_adjust_dialog_sizes === 'function' ) {
+                redmond_adjust_dialog_sizes();
+        }
+
+        jQuery(window).on('resize',function() {
+                if ( typeof redmond_adjust_dialog_sizes === 'function' ) {
+                        redmond_adjust_dialog_sizes();
+                }
         });
 });
 
 function checkOpenWindows() {
-	processList = '';
-	for( var process in processes ) {
-		if( parseInt(processes[process].parent().css('top'),10) >= 0 ) {
-			processes[process].currentTop = parseInt(processes[process].parent().css('top'),10);
-		}
-		else {
-			processes[process].parent().css('top',processes[process].currentTop);
-		}
-		processList += '<li onclick="processes[\'' +process+ '\'].dialog(\'moveToTop\')" id="' +process+ '_taskbar">';
-		processList += '<span class="task-icon"';
-		processList += ' style="' + processes[process].parent().find('.ui-dialog-title').attr('style') + '"';
-		processList += '></span>';
-		processList += processes[process].parent().find('.ui-dialog-title').html().substring(0,20) + '</li>' + "\r\n";
-	}
-	jQuery("#open-processes").html( processList );
+        var processList = '';
+        for( var process in processes ) {
+                if ( ! Object.prototype.hasOwnProperty.call(processes, process) ) {
+                        continue;
+                }
+
+                if ( typeof processes[process].dialog !== 'function' || ! processes[process].dialog('isOpen') ) {
+                        continue;
+                }
+
+                if( parseInt(processes[process].parent().css('top'),10) >= 0 ) {
+                        processes[process].currentTop = parseInt(processes[process].parent().css('top'),10);
+                }
+                else {
+                        processes[process].parent().css('top',processes[process].currentTop);
+                }
+                processList += '<li onclick="processes[\'' +process+ '\'].dialog(\'moveToTop\')" id="' +process+ '_taskbar">';
+                processList += '<span class="task-icon"';
+                processList += ' style="' + processes[process].parent().find('.ui-dialog-title').attr('style') + '"';
+                processList += '></span>';
+                processList += processes[process].parent().find('.ui-dialog-title').html().substring(0,20) + '</li>' + "\r\n";
+        }
+        jQuery("#open-processes").html( processList );
 	jQuery("#open-processes>li").on('click',function() {
 		find_window_on_top();
 	});
@@ -87,20 +90,34 @@ function checkOpenWindows() {
 
 function find_window_on_top() {
 	var top;
-	var hightestZ = 0;
-	for( var process in processes ) {
-		if( processes[process].zIndex() > hightestZ ) {
-			top = process;
-			hightestZ = processes[process].zIndex();
-		}
-		var currTop = processes[process].parent().offset().top;
-		if( currTop < 0 ) {
-			processes[process].parent().offset({top: 100, left: processes[process].parent().offset().left});
-		}
-	}
-	var taskbar = jQuery("#" + top + '_taskbar');
-	jQuery("#open-processes>li").removeClass('active');
-	taskbar.addClass('active');
+        var hightestZ = -Infinity;
+        for( var process in processes ) {
+                if ( ! Object.prototype.hasOwnProperty.call(processes, process) ) {
+                        continue;
+                }
+
+                if ( typeof processes[process].dialog !== 'function' || ! processes[process].dialog('isOpen') ) {
+                        continue;
+                }
+
+                if( processes[process].zIndex() > hightestZ ) {
+                        top = process;
+                        hightestZ = processes[process].zIndex();
+                }
+                var currTop = processes[process].parent().offset().top;
+                if( currTop < 0 ) {
+                        processes[process].parent().offset({top: 100, left: processes[process].parent().offset().left});
+                }
+        }
+
+        jQuery("#open-processes>li").removeClass('active');
+
+        if ( typeof top === 'undefined' ) {
+                return;
+        }
+
+        var taskbar = jQuery("#" + top + '_taskbar');
+        taskbar.addClass('active');
 }
 
 function startSystemClock() {

--- a/resources/redmond-dialogs.js
+++ b/resources/redmond-dialogs.js
@@ -39,24 +39,28 @@ function redmond_window( objid , title , content , filecommands , canResize , dr
                         draggable: draggable,
                         resizable: canResize,
                         position: {
-                                my: 'center',
-                                at: 'center',
+                                my: 'center top',
+                                at: 'center top+40',
                                 of: workspaceTarget,
                                 collision: 'fit'
                         },
                         close: function( event, ui ) {
-                                processes[objid].remove();
-                                delete processes[objid];
-				jQuery(window).trigger('checkOpenWindows');
-			},
-			open: function( event, ui ) {
-				processes[objid].find('div.file-bar>ul').append(redmond_filecommands_to_html(filecommands));
-				processes[objid].parent().find('.ui-dialog-titlebar>span').css({
-					'background-image': 'url(' + icon + ')',
-					'background-repeat': 'no-repeat',
-					'background-size': 'contain',
-				});
-                                processes[objid].parent().find('button.ui-dialog-titlebar-close')
+                                processes[objid].parent().addClass('redmond-dialog-hidden');
+                                jQuery(window).trigger('checkOpenWindows');
+                        },
+                        open: function( event, ui ) {
+                                processes[objid].find('div.file-bar>ul').append(redmond_filecommands_to_html(filecommands));
+                                processes[objid].parent().find('.ui-dialog-titlebar>span').css({
+                                        'background-image': 'url(' + icon + ')',
+                                        'background-repeat': 'no-repeat',
+                                        'background-size': 'contain',
+                                });
+                                processes[objid].dialog('option', 'closeText', '');
+                                processes[objid].parent().removeClass('redmond-dialog-hidden');
+
+                                var closeButton = processes[objid].parent().find('button.ui-dialog-titlebar-close');
+                                redmond_style_close_button(closeButton);
+                                closeButton
                                         .off('click.redmondClose')
                                         .on('click.redmondClose', function(e){
                                                 e.preventDefault();
@@ -65,26 +69,32 @@ function redmond_window( objid , title , content , filecommands , canResize , dr
                                         });
                                 processes[objid].find('div.file-bar').zIndex(processes[objid].zIndex());
                                 jQuery(window).trigger('checkOpenWindows');
-                                processes[objid].parent().on('click',function() {
-                                        find_window_on_top();
+                                processes[objid].parent()
+                                        .off('click.redmondFocus')
+                                        .on('click.redmondFocus', function() {
+                                                find_window_on_top();
+                                        });
+                                processes[objid].find('iframe')
+                                        .off('click.redmondIframe')
+                                        .on('click.redmondIframe', function() {
+                                                processes[objid].dialog('moveToTop');
+                                                find_window_on_top();
+                                        });
+                                processes[objid].find('span.dialog-close-button').css({
+                                        left: function() {
+                                                var fullwidth = parseInt( processes[objid].find('span.dialog-close-button').parent().css('width') , 10 );
+                                                return ( fullwidth / 2 ) - ( parseInt( processes[objid].find('span.dialog-close-button').css('width') , 10 ) / 2 ) - 10;
+                                        }
                                 });
-				processes[objid].find('iframe').on('click',function() {
-					processes[objid].dialog('moveToTop');
-					find_window_on_top();
-				});
-				processes[objid].find('span.dialog-close-button').css({
-					left: function() {
-						var fullwidth = parseInt( processes[objid].find('span.dialog-close-button').parent().css('width') , 10 );
-						return ( fullwidth / 2 ) - ( parseInt( processes[objid].find('span.dialog-close-button').css('width') , 10 ) / 2 ) - 10;
-					}
-				});
-			},
-			focus: function( event, ui ) {
-				processes[objid].find('div.file-bar').zIndex(processes[objid].zIndex());
-				find_window_on_top();
-			},
+
+                                redmond_adjust_dialog_sizes();
+                        },
+                        focus: function( event, ui ) {
+                                processes[objid].find('div.file-bar').zIndex(processes[objid].zIndex());
+                                find_window_on_top();
+                        },
 			title: title,
-			closeText: "\u00d7",
+			closeText: '',
 			width: 'auto',
 			height: 'auto',
 		});
@@ -92,12 +102,29 @@ function redmond_window( objid , title , content , filecommands , canResize , dr
 	else {
 		processes[objid].html('<div class="file-bar"><ul></ul></div>' + content + '</div>');
                 processes[objid].find('div.file-bar>ul').append(redmond_filecommands_to_html(filecommands));
+                processes[objid].dialog('option', {
+                        appendTo: workspaceTarget,
+                        closeOnEscape: false,
+                        draggable: draggable,
+                        resizable: canResize,
+                        position: {
+                                my: 'center top',
+                                at: 'center top+40',
+                                of: workspaceTarget,
+                                collision: 'fit'
+                        },
+                        closeText: ''
+                });
+
+                processes[objid].parent().removeClass('redmond-dialog-hidden');
                 processes[objid].parent().find('.ui-dialog-titlebar>span').css({
                         'background-image': 'url(' + icon + ')',
                         'background-repeat': 'no-repeat',
                         'background-size': 'contain',
                 });
-                processes[objid].parent().find('button.ui-dialog-titlebar-close')
+                var closeButton = processes[objid].parent().find('button.ui-dialog-titlebar-close');
+                redmond_style_close_button(closeButton);
+                closeButton
                         .off('click.redmondClose')
                         .on('click.redmondClose', function(e){
                                 e.preventDefault();
@@ -105,53 +132,23 @@ function redmond_window( objid , title , content , filecommands , canResize , dr
                                 redmond_close_this(this);
                         });
                 processes[objid].find('div.file-bar').zIndex(processes[objid].zIndex());
-		jQuery(window).trigger('checkOpenWindows');
-		processes[objid].parent().on('click',function() {
-			find_window_on_top();
-		});
-		processes[objid].find('span.dialog-close-button').css({
-			left: function() {
-				var fullwidth = parseInt( processes[objid].find('span.dialog-close-button').parent().css('width') , 10 );
-				return ( fullwidth / 2 ) - ( parseInt( processes[objid].find('span.dialog-close-button').css('width') , 10 ) / 2 ) - 10;
-			}
-		});
-                processes[objid].dialog('moveToTop');
-                processes[objid].dialog('option', 'appendTo', workspaceTarget);
-                processes[objid].dialog('option', 'position', {
-                        my: 'center',
-                        at: 'center',
-                        of: workspaceTarget,
-                        collision: 'fit'
+                jQuery(window).trigger('checkOpenWindows');
+                processes[objid].parent()
+                        .off('click.redmondFocus')
+                        .on('click.redmondFocus', function() {
+                                find_window_on_top();
+                        });
+                processes[objid].find('span.dialog-close-button').css({
+                        left: function() {
+                                var fullwidth = parseInt( processes[objid].find('span.dialog-close-button').parent().css('width') , 10 );
+                                return ( fullwidth / 2 ) - ( parseInt( processes[objid].find('span.dialog-close-button').css('width') , 10 ) / 2 ) - 10;
+                        }
                 });
+                processes[objid].dialog('open');
+                processes[objid].dialog('moveToTop');
                 find_window_on_top();
         }
-        jQuery("div.redmond-dialog-window").each(function() {
-                var dialogWrapper = jQuery(this);
-                var workspace = jQuery('#desktop-window-area');
-                var viewportHeight = workspace.length ? workspace.innerHeight() : jQuery(window).height();
-                var maxWindowHeight = Math.floor(viewportHeight * 0.9);
-                var titleBarHeight = dialogWrapper.children('.ui-dialog-titlebar').outerHeight(true) || 0;
-                var contentArea = dialogWrapper.children('.ui-dialog-content');
-                var maxContentHeight = maxWindowHeight - titleBarHeight;
-
-                if ( maxContentHeight < 120 ) {
-                        maxContentHeight = Math.max(viewportHeight - titleBarHeight - 20, 120);
-                }
-
-                dialogWrapper.css({
-                        'padding-bottom': dialogWrapper.outerHeight() > maxWindowHeight ? 20 : '',
-                        'max-height': maxWindowHeight,
-                        'overflow-y': 'auto',
-                        'overflow-x': 'visible'
-                });
-
-                contentArea.css({
-                        'max-height': maxContentHeight,
-                        'overflow-y': 'auto',
-                        'overflow-x': 'auto',
-                        'height': ''
-                });
-        });
+        redmond_adjust_dialog_sizes();
 }
 
 function redmond_filecommands_to_html( filecommands ) {
@@ -167,6 +164,94 @@ function redmond_filecommands_to_html( filecommands ) {
 	html += '	</ul>' + "\r\n";
 	html += '</li>' + "\r\n";
 	return html;
+}
+
+function redmond_style_close_button( closeButton ) {
+        if ( ! closeButton || ! closeButton.length ) {
+                return;
+        }
+
+        var closeLabel = ( window.redmond_terms && redmond_terms.close ) ? redmond_terms.close : 'Close';
+
+        closeButton
+                .removeClass('ui-button-icon-only')
+                .addClass('redmond-close-button')
+                .attr('title', closeLabel)
+                .attr('aria-label', closeLabel);
+
+        closeButton.find('span.ui-icon').remove();
+        closeButton.find('span.ui-button-icon-space').remove();
+        closeButton
+                .contents()
+                .filter(function(){
+                        return this.nodeType === 3;
+                })
+                .remove();
+        closeButton.find('span.redmond-close-text').remove();
+        closeButton.append('<span class="redmond-close-text" aria-hidden="true">&times;</span>');
+}
+
+function redmond_adjust_dialog_sizes() {
+        var workspace = jQuery('#desktop-window-area');
+        var viewportHeight = workspace.length ? workspace.innerHeight() : jQuery(window).height();
+        if ( ! viewportHeight || viewportHeight <= 0 ) {
+                return;
+        }
+
+        var targetWindowHeight = Math.max(Math.floor(viewportHeight * 0.5), 1);
+
+        var positionTarget = workspace.length ? workspace : jQuery(window);
+
+        jQuery('div.redmond-dialog-window').each(function() {
+                var dialogWrapper = jQuery(this);
+                var titleBar = dialogWrapper.children('.ui-dialog-titlebar');
+                var contentArea = dialogWrapper.children('.ui-dialog-content');
+                var titleBarHeight = titleBar.outerHeight(true) || 0;
+                var contentHeight = Math.max(targetWindowHeight - titleBarHeight, 0);
+
+                dialogWrapper.css({
+                        'height': targetWindowHeight,
+                        'min-height': targetWindowHeight,
+                        'max-height': targetWindowHeight,
+                        'overflow-y': 'hidden',
+                        'overflow-x': 'visible',
+                        'padding-bottom': ''
+                });
+
+                var contentStyles = {
+                        'overflow-y': 'auto',
+                        'overflow-x': 'auto'
+                };
+
+                if ( contentHeight > 0 ) {
+                        contentStyles.height = contentHeight;
+                        contentStyles['max-height'] = contentHeight;
+                } else {
+                        contentStyles.height = '';
+                        contentStyles['max-height'] = '';
+                }
+
+                contentArea.css(contentStyles);
+
+                var dialogInstance = contentArea.data('ui-dialog') || contentArea.data('dialog');
+
+                if ( dialogInstance ) {
+                        var dialogOptions = {
+                                position: {
+                                        my: 'center top',
+                                        at: 'center top+40',
+                                        of: positionTarget,
+                                        collision: 'fit'
+                                }
+                        };
+
+                        if ( contentHeight > 0 ) {
+                                dialogOptions.height = contentHeight;
+                        }
+
+                        contentArea.dialog('option', dialogOptions);
+                }
+        });
 }
 
 function redmond_close_this( obj ) {

--- a/style.css
+++ b/style.css
@@ -416,24 +416,28 @@ ul.archives-inner-wrapper>li:hover, ul.archives-inner-wrapper>li:focus, ul.archi
 }
 
 div.redmond-dialog-window {
-	z-index: 500;
-	background: var(--redmond-surface-alt);
-	background-color: var(--redmond-surface-alt);
-	min-height: 20px;
-	border: solid 1px;
-	border-top-color: var(--redmond-border-highlight);
-	border-left-color: var(--redmond-border-highlight);
-	border-right-color: var(--redmond-border-dark);
-	border-bottom-color: var(--redmond-border-dark);
-	display: inline-block;
-	max-width: 100%;
-	max-height: 100%;
-	position: absolute !important;
+        z-index: 500;
+        background: var(--redmond-surface-alt);
+        background-color: var(--redmond-surface-alt);
+        min-height: 20px;
+        border: solid 1px;
+        border-top-color: var(--redmond-border-highlight);
+        border-left-color: var(--redmond-border-highlight);
+        border-right-color: var(--redmond-border-dark);
+        border-bottom-color: var(--redmond-border-dark);
+        display: inline-block;
+        max-width: 100%;
+        max-height: 100%;
+        position: absolute !important;
+}
+
+div.redmond-dialog-window.redmond-dialog-hidden {
+        display: none !important;
 }
 
 div.redmond-dialog-window>.ui-dialog-content, div.redmond-dialog-window>.ui-dialog-titlebar {
-	min-width: 300px;
-	display: block;
+        min-width: 300px;
+        display: block;
 }
 
 div.redmond-dialog-window>.ui-dialog-content {
@@ -464,24 +468,43 @@ div.redmond-dialog-window>.ui-dialog-titlebar>span {
 }
 
 div.redmond-dialog-window>.ui-dialog-titlebar>button {
-	position: absolute;
-	top: 1px;
-	right: 1px;
-	background: var(--redmond-surface);
-	background-color: var(--redmond-surface);
-	min-height: 20px;
-	border: solid 1px;
-	border-top-color: var(--redmond-border-highlight);
-	border-left-color: var(--redmond-border-highlight);
-	border-right-color: var(--redmond-border-dark);
-	border-bottom-color: var(--redmond-border-dark);
-	display: inline-block;
-	padding: 0;
-	line-height: 0;
-	height: auto;
-	width: 20px;
-	font-weight: 700;
-	color: var(--redmond-text);
+        position: absolute;
+        top: 1px;
+        right: 1px;
+        background: var(--redmond-surface);
+        background-color: var(--redmond-surface);
+        min-height: 20px;
+        border: solid 1px;
+        border-top-color: var(--redmond-border-highlight);
+        border-left-color: var(--redmond-border-highlight);
+        border-right-color: var(--redmond-border-dark);
+        border-bottom-color: var(--redmond-border-dark);
+        display: inline-block;
+        padding: 0;
+        line-height: 1;
+        height: auto;
+        width: 22px;
+        font-weight: 700;
+        color: var(--redmond-text);
+}
+
+div.redmond-dialog-window>.ui-dialog-titlebar>button.redmond-close-button {
+        display: flex;
+        align-items: center;
+        justify-content: center;
+        font-size: 16px;
+        padding: 0;
+}
+
+div.redmond-dialog-window>.ui-dialog-titlebar>button.redmond-close-button .redmond-close-text {
+        line-height: 1;
+        font-size: 16px;
+        display: block;
+}
+
+div.redmond-dialog-window>.ui-dialog-titlebar>button.redmond-close-button:focus-visible {
+        outline: 2px solid var(--redmond-accent);
+        outline-offset: 1px;
 }
 
 div.redmond-dialog-window>div.ui-dialog-content {


### PR DESCRIPTION
## Summary
- ensure the taskbar process list uses a local accumulator and ignores closed dialogs
- restyle the dialog close control, prevent duplicate focus handlers, and reuse reopen options so hiding/showing windows stays consistent
- enforce a 50% viewport dialog height with scrollable content and shared positioning logic when dialogs open or resize

## Testing
- not run (not requested)

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_690fa6ee89c8832a842139bf4060478b)