### PR TITLE
Harden dialog controls and restore start menu content

### DIFF
--- a/header.php
+++ b/header.php
@@ -67,25 +67,40 @@ $current_user = wp_get_current_user();
 					<div class="row">
 						<div class="col-xs-6">
 							<div id="start-menu-posts">
-						<?php
-							$latest = wp_get_recent_posts( array(
-								'numberposts' => 8,
-								'post_status' => 'publish',
-								'suppress_filters' => false,
-							) , OBJECT );
-							foreach ( $latest as $post ) {
-								?>
-									<a href="<?php print esc_url( get_permalink( $post->ID ) ); ?>" class="post-link" data-post-id="<?php print intval( $post->ID ); ?>" title="<?php print esc_html( $post->post_title ); ?>">
-										<img src="<?php print esc_url( redmond_get_post_icon( $post->ID ) ); ?>" />
-										<?php print esc_html( substr( $post->post_title, 0, 20 ) ); ?>
-										<?php if ( strlen( esc_html( $post->post_title ) ) > 20 ) { print '...'; } ?>
-									</a>
-								<?php
-							}
-						?>
-							</div>
-						</div>
-						<div class="col-xs-6">
+                                                <?php
+                                                        $recent_items = get_posts( array(
+                                                                'post_type' => array( 'post', 'page' ),
+                                                                'post_status' => 'publish',
+                                                                'posts_per_page' => 8,
+                                                                'orderby' => 'date',
+                                                                'order' => 'DESC',
+                                                                'suppress_filters' => false,
+                                                        ) );
+
+                                                        if ( empty( $recent_items ) ) {
+                                                                ?>
+                                                                <span class="start-menu-empty">
+                                                                        <?php esc_html_e( 'No recent content available yet.', RTEXTDOMAIN ); ?>
+                                                                </span>
+                                                                <?php
+                                                        }
+                                                        else {
+                                                                foreach ( $recent_items as $recent_post ) {
+                                                                        $recent_title = get_the_title( $recent_post );
+                                                                        $recent_label = wp_html_excerpt( $recent_title, 20, '...' );
+                                                                        ?>
+                                                                        <a href="<?php print esc_url( get_permalink( $recent_post ) ); ?>" class="post-link" data-post-id="<?php print intval( $recent_post->ID ); ?>" title="<?php print esc_attr( $recent_title ); ?>">
+                                                                                <img src="<?php print esc_url( redmond_get_post_icon( $recent_post->ID ) ); ?>" />
+                                                                                <?php print esc_html( $recent_label ); ?>
+                                                                        </a>
+                                                                        <?php
+                                                                }
+                                                                wp_reset_postdata();
+                                                        }
+                                                ?>
+                                                        </div>
+                                                </div>
+                                                <div class="col-xs-6">
 							<div id="start-menu-content-links">
 								<a id="my-documents-start-menu-link">
 									<img src="<?php print esc_url( get_theme_mod( 'redmond_default_documents_icon' , REDMONDURI . '/resources/docs.ico' ) ); ?>" />

--- a/resources/redmond-dialogs.js
+++ b/resources/redmond-dialogs.js
@@ -39,119 +39,124 @@ function redmond_window( objid , title , content , filecommands , canResize , dr
                         draggable: draggable,
                         resizable: canResize,
                         position: {
-                                my: 'center',
-                                at: 'center',
+                                my: 'center top',
+                                at: 'center top+40',
                                 of: workspaceTarget,
                                 collision: 'fit'
                         },
                         close: function( event, ui ) {
-                                processes[objid].remove();
-                                delete processes[objid];
-				jQuery(window).trigger('checkOpenWindows');
-			},
-			open: function( event, ui ) {
-				processes[objid].find('div.file-bar>ul').append(redmond_filecommands_to_html(filecommands));
-				processes[objid].parent().find('.ui-dialog-titlebar>span').css({
-					'background-image': 'url(' + icon + ')',
-					'background-repeat': 'no-repeat',
-					'background-size': 'contain',
-				});
-                                processes[objid].parent().find('button.ui-dialog-titlebar-close')
+                                processes[objid].parent().addClass('redmond-dialog-hidden');
+                                jQuery(window).trigger('checkOpenWindows');
+                        },
+                        open: function( event, ui ) {
+                                processes[objid].find('div.file-bar>ul').append(redmond_filecommands_to_html(filecommands));
+                                processes[objid].parent().find('.ui-dialog-titlebar>span').css({
+                                        'background-image': 'url(' + icon + ')',
+                                        'background-repeat': 'no-repeat',
+                                        'background-size': 'contain',
+                                });
+                                processes[objid].dialog('option', 'closeText', '');
+                                processes[objid].parent()
+                                        .attr('data-redmond-process-id', objid)
+                                        .removeClass('redmond-dialog-hidden');
+
+                                var closeButton = processes[objid].parent().find('button.ui-dialog-titlebar-close');
+                                redmond_style_close_button(closeButton);
+                                closeButton
                                         .off('click.redmondClose')
-                                        .on('click.redmondClose', function(e){
-                                                e.preventDefault();
-                                                e.stopPropagation();
+                                        .on('click.redmondClose', function(event){
+                                                event.preventDefault();
+                                                event.stopPropagation();
                                                 redmond_close_this(this);
                                         });
                                 processes[objid].find('div.file-bar').zIndex(processes[objid].zIndex());
                                 jQuery(window).trigger('checkOpenWindows');
-                                processes[objid].parent().on('click',function() {
-                                        find_window_on_top();
+                                processes[objid].parent()
+                                        .off('click.redmondFocus')
+                                        .on('click.redmondFocus', function() {
+                                                find_window_on_top();
+                                        });
+                                processes[objid].find('iframe')
+                                        .off('click.redmondIframe')
+                                        .on('click.redmondIframe', function() {
+                                                processes[objid].dialog('moveToTop');
+                                                find_window_on_top();
+                                        });
+                                processes[objid].find('span.dialog-close-button').css({
+                                        left: function() {
+                                                var fullwidth = parseInt( processes[objid].find('span.dialog-close-button').parent().css('width') , 10 );
+                                                return ( fullwidth / 2 ) - ( parseInt( processes[objid].find('span.dialog-close-button').css('width') , 10 ) / 2 ) - 10;
+                                        }
                                 });
-				processes[objid].find('iframe').on('click',function() {
-					processes[objid].dialog('moveToTop');
-					find_window_on_top();
-				});
-				processes[objid].find('span.dialog-close-button').css({
-					left: function() {
-						var fullwidth = parseInt( processes[objid].find('span.dialog-close-button').parent().css('width') , 10 );
-						return ( fullwidth / 2 ) - ( parseInt( processes[objid].find('span.dialog-close-button').css('width') , 10 ) / 2 ) - 10;
-					}
-				});
-			},
-			focus: function( event, ui ) {
-				processes[objid].find('div.file-bar').zIndex(processes[objid].zIndex());
-				find_window_on_top();
-			},
+
+                                redmond_adjust_dialog_sizes();
+                        },
+                        focus: function( event, ui ) {
+                                processes[objid].find('div.file-bar').zIndex(processes[objid].zIndex());
+                                find_window_on_top();
+                        },
 			title: title,
-			closeText: "\u00d7",
+			closeText: '',
 			width: 'auto',
-			height: 'auto',
-		});
-	}
-	else {
-		processes[objid].html('<div class="file-bar"><ul></ul></div>' + content + '</div>');
+                        height: 'auto',
+                });
+                processes[objid].parent()
+                        .attr('data-redmond-limit-height', canResize ? 'true' : 'false')
+                        .attr('data-redmond-process-id', objid);
+        }
+        else {
+                processes[objid].html('<div class="file-bar"><ul></ul></div>' + content + '</div>');
                 processes[objid].find('div.file-bar>ul').append(redmond_filecommands_to_html(filecommands));
+                processes[objid].dialog('option', {
+                        appendTo: workspaceTarget,
+                        closeOnEscape: false,
+                        draggable: draggable,
+                        resizable: canResize,
+                        position: {
+                                my: 'center top',
+                                at: 'center top+40',
+                                of: workspaceTarget,
+                                collision: 'fit'
+                        },
+                        closeText: ''
+                });
+
+                processes[objid].parent()
+                        .attr('data-redmond-limit-height', canResize ? 'true' : 'false')
+                        .attr('data-redmond-process-id', objid)
+                        .removeClass('redmond-dialog-hidden');
                 processes[objid].parent().find('.ui-dialog-titlebar>span').css({
                         'background-image': 'url(' + icon + ')',
                         'background-repeat': 'no-repeat',
                         'background-size': 'contain',
                 });
-                processes[objid].parent().find('button.ui-dialog-titlebar-close')
+                var closeButton = processes[objid].parent().find('button.ui-dialog-titlebar-close');
+                redmond_style_close_button(closeButton);
+                closeButton
                         .off('click.redmondClose')
-                        .on('click.redmondClose', function(e){
-                                e.preventDefault();
-                                e.stopPropagation();
+                        .on('click.redmondClose', function(event){
+                                event.preventDefault();
+                                event.stopPropagation();
                                 redmond_close_this(this);
                         });
                 processes[objid].find('div.file-bar').zIndex(processes[objid].zIndex());
-		jQuery(window).trigger('checkOpenWindows');
-		processes[objid].parent().on('click',function() {
-			find_window_on_top();
-		});
-		processes[objid].find('span.dialog-close-button').css({
-			left: function() {
-				var fullwidth = parseInt( processes[objid].find('span.dialog-close-button').parent().css('width') , 10 );
-				return ( fullwidth / 2 ) - ( parseInt( processes[objid].find('span.dialog-close-button').css('width') , 10 ) / 2 ) - 10;
-			}
-		});
-                processes[objid].dialog('moveToTop');
-                processes[objid].dialog('option', 'appendTo', workspaceTarget);
-                processes[objid].dialog('option', 'position', {
-                        my: 'center',
-                        at: 'center',
-                        of: workspaceTarget,
-                        collision: 'fit'
+                jQuery(window).trigger('checkOpenWindows');
+                processes[objid].parent()
+                        .off('click.redmondFocus')
+                        .on('click.redmondFocus', function() {
+                                find_window_on_top();
+                        });
+                processes[objid].find('span.dialog-close-button').css({
+                        left: function() {
+                                var fullwidth = parseInt( processes[objid].find('span.dialog-close-button').parent().css('width') , 10 );
+                                return ( fullwidth / 2 ) - ( parseInt( processes[objid].find('span.dialog-close-button').css('width') , 10 ) / 2 ) - 10;
+                        }
                 });
+                processes[objid].dialog('open');
+                processes[objid].dialog('moveToTop');
                 find_window_on_top();
         }
-        jQuery("div.redmond-dialog-window").each(function() {
-                var dialogWrapper = jQuery(this);
-                var workspace = jQuery('#desktop-window-area');
-                var viewportHeight = workspace.length ? workspace.innerHeight() : jQuery(window).height();
-                var maxWindowHeight = Math.floor(viewportHeight * 0.9);
-                var titleBarHeight = dialogWrapper.children('.ui-dialog-titlebar').outerHeight(true) || 0;
-                var contentArea = dialogWrapper.children('.ui-dialog-content');
-                var maxContentHeight = maxWindowHeight - titleBarHeight;
-
-                if ( maxContentHeight < 120 ) {
-                        maxContentHeight = Math.max(viewportHeight - titleBarHeight - 20, 120);
-                }
-
-                dialogWrapper.css({
-                        'padding-bottom': dialogWrapper.outerHeight() > maxWindowHeight ? 20 : '',
-                        'max-height': maxWindowHeight,
-                        'overflow-y': 'auto',
-                        'overflow-x': 'visible'
-                });
-
-                contentArea.css({
-                        'max-height': maxContentHeight,
-                        'overflow-y': 'auto',
-                        'overflow-x': 'auto',
-                        'height': ''
-                });
-        });
+        redmond_adjust_dialog_sizes();
 }
 
 function redmond_filecommands_to_html( filecommands ) {
@@ -169,26 +174,128 @@ function redmond_filecommands_to_html( filecommands ) {
 	return html;
 }
 
+function redmond_style_close_button( closeButton ) {
+        if ( ! closeButton || ! closeButton.length ) {
+                return;
+        }
+
+        var closeLabel = ( window.redmond_terms && redmond_terms.close ) ? redmond_terms.close : 'Close';
+
+        closeButton
+                .removeClass('ui-button-icon-only')
+                .addClass('redmond-close-button')
+                .attr('type', 'button')
+                .attr('title', closeLabel)
+                .attr('aria-label', closeLabel);
+
+        closeButton.find('span.ui-icon').remove();
+        closeButton.find('span.ui-button-icon-space').remove();
+        closeButton
+                .contents()
+                .filter(function(){
+                        return this.nodeType === 3;
+                })
+                .remove();
+        closeButton.find('span.redmond-close-text').remove();
+        closeButton.append('<span class="redmond-close-text" aria-hidden="true">&times;</span>');
+}
+
+function redmond_adjust_dialog_sizes() {
+        var workspace = jQuery('#desktop-window-area');
+        var viewportHeight = workspace.length ? workspace.innerHeight() : jQuery(window).height();
+        if ( ! viewportHeight || viewportHeight <= 0 ) {
+                return;
+        }
+
+        var halfViewport = Math.round(viewportHeight * 0.5);
+        var availableHeight = Math.max(Math.min(halfViewport, viewportHeight - 80), 240);
+        var positionTarget = workspace.length ? workspace : jQuery(window);
+
+        jQuery('div.redmond-dialog-window').each(function() {
+                var dialogWrapper = jQuery(this);
+                var shouldCapHeight = dialogWrapper.attr('data-redmond-limit-height') !== 'false';
+                var titleBar = dialogWrapper.children('.ui-dialog-titlebar');
+                var contentArea = dialogWrapper.children('.ui-dialog-content');
+                var titleBarHeight = titleBar.outerHeight(true) || 0;
+                var fileBar = contentArea.children('.file-bar').first();
+                var fileBarHeight = fileBar.length ? (fileBar.outerHeight(true) || 0) : 0;
+                var maxContentHeight = Math.max(availableHeight - titleBarHeight - fileBarHeight, 200);
+
+                dialogWrapper.css({
+                        'height': '',
+                        'min-height': '',
+                        'max-height': shouldCapHeight ? availableHeight : '',
+                        'overflow-y': 'visible',
+                        'overflow-x': 'visible',
+                        'padding-bottom': ''
+                });
+
+                var contentStyles = {
+                        'overflow-y': 'auto',
+                        'overflow-x': 'auto',
+                        'min-height': '',
+                        'height': '',
+                        'max-height': shouldCapHeight ? maxContentHeight : ''
+                };
+
+                contentArea.css(contentStyles);
+
+                var dialogInstance = contentArea.data('ui-dialog') || contentArea.data('dialog');
+
+                if ( dialogInstance ) {
+                        var dialogOptions = {
+                                position: {
+                                        my: 'center top',
+                                        at: 'center top+40',
+                                        of: positionTarget,
+                                        collision: 'fit'
+                                },
+                                height: 'auto',
+                                maxHeight: shouldCapHeight ? availableHeight : false
+                        };
+
+                        contentArea.dialog('option', dialogOptions);
+                }
+        });
+}
+
 function redmond_close_this( obj ) {
-        var $obj = jQuery(obj);
-        var dialogContent = $obj.closest('.ui-dialog-content');
+        var $trigger = jQuery(obj);
+        var dialogWrapper = $trigger.closest('.ui-dialog');
+        var closed = false;
 
-        if ( ! dialogContent.length ) {
-                var dialogWrapper = $obj.closest('.ui-dialog');
+        if ( dialogWrapper.length ) {
+                var processId = dialogWrapper.attr('data-redmond-process-id');
 
-                if ( dialogWrapper.length ) {
-                        var dialogInstance = dialogWrapper.data('ui-dialog') || dialogWrapper.data('dialog');
+                if ( processId && processes[processId] && typeof processes[processId].dialog === 'function' ) {
+                        processes[processId].dialog('close');
+                        closed = true;
+                }
 
-                        if ( dialogInstance && typeof dialogInstance.close === 'function' ) {
-                                dialogInstance.close();
-                                return;
+                if ( ! closed ) {
+                        var dialogContent = dialogWrapper.children('.ui-dialog-content').first();
+
+                        if ( dialogContent.length && typeof dialogContent.dialog === 'function' ) {
+                                dialogContent.dialog('close');
+                                closed = true;
                         }
+                }
 
-                        dialogContent = dialogWrapper.find('.ui-dialog-content').first();
+                dialogWrapper.addClass('redmond-dialog-hidden');
+        }
+        else {
+                var dialogContent = $trigger.closest('.ui-dialog-content');
+
+                if ( dialogContent.length && typeof dialogContent.dialog === 'function' ) {
+                        dialogContent.dialog('close');
+                        dialogContent.closest('.ui-dialog').addClass('redmond-dialog-hidden');
+                        closed = true;
                 }
         }
 
-        if ( dialogContent.length ) {
-                dialogContent.dialog('close');
+        if ( ! closed ) {
+                $trigger.closest('.redmond-dialog-window').addClass('redmond-dialog-hidden');
         }
+
+        jQuery(window).trigger('checkOpenWindows');
 }

--- a/style.css
+++ b/style.css
@@ -1,9 +1,9 @@
 /*
-Theme Name:         Redmond Inspired
+Theme Name:         Longhorn Inspired
 Theme URI:          https://jak.guru
-Description:        WordPress theme inspired by classic Windows Operating Systems
+Description:        WordPress theme inspired by the Windows Longhorn aesthetic
 Version:            1.0.0
-Author:             Jak Gurudiv.file-bar
+Author:             Jak Guru
 Author URI:         https://jak.guru
 
 License:            MIT License
@@ -11,18 +11,18 @@ License URI:        http://opensource.org/licenses/MIT
 */
 
 :root {
-	--redmond-bg: #0b1120;
-	--redmond-surface: #111827;
-	--redmond-surface-alt: #1f2937;
-	--redmond-surface-soft: #182133;
-	--redmond-border-light: #475569;
-	--redmond-border-highlight: #64748b;
-	--redmond-border-dark: #050b18;
-	--redmond-border-darker: #030712;
-	--redmond-text: #e2e8f0;
-	--redmond-text-muted: #cbd5f5;
-	--redmond-accent: #60a5fa;
-	--redmond-accent-dark: #1e3a8a;
+	--redmond-bg: #050607;
+	--redmond-surface: #0f1014;
+	--redmond-surface-alt: #15161d;
+	--redmond-surface-soft: #1b1d26;
+	--redmond-border-light: #ff5757;
+	--redmond-border-highlight: #ff6f6f;
+	--redmond-border-dark: #09090f;
+	--redmond-border-darker: #050508;
+	--redmond-text: #f5f5f7;
+	--redmond-text-muted: #ffb6c1;
+	--redmond-accent: #ff4d4f;
+	--redmond-accent-dark: #b1001d;
 }
 
 :focus {
@@ -41,10 +41,13 @@ code {
 }
 
 html, body {
-	height: 100%;
-	overflow-x: hidden;
-	overflow-y: hidden;
-	background: var(--redmond-bg);
+        height: 100%;
+        overflow-x: hidden;
+        overflow-y: scroll;
+        background-color: var(--redmond-bg);
+        background-image: radial-gradient(circle at 15% 20%, rgba(255,77,79,0.35), rgba(5,6,7,0.95) 55%);
+        background-repeat: no-repeat;
+        background-attachment: fixed;
 }
 
 body, body.custom-background {
@@ -52,26 +55,28 @@ body, body.custom-background {
 }
 
 #taskbar-outer {
-	display: block;
-	position: fixed;
-	bottom: 0;
-	left: 0;
-	background: var(--redmond-surface-alt);
-	background-color: var(--redmond-surface-alt);
-	border-top: solid 1px var(--redmond-border-light);
-	border-bottom: solid 1px var(--redmond-border-dark);
-	height: 30px;
-	width: 100%;
-	border-radius: 0;
-	z-index: 10000;
+        display: block;
+        position: fixed;
+        bottom: 0;
+        left: 0;
+        background: linear-gradient(180deg, rgba(24,24,28,0.95) 0%, rgba(8,8,10,0.98) 55%, rgba(255,77,79,0.18) 100%);
+        background-color: var(--redmond-surface-alt);
+        border-top: solid 1px var(--redmond-border-light);
+        border-bottom: solid 1px var(--redmond-border-dark);
+        height: 30px;
+        width: 100%;
+        border-radius: 0;
+        z-index: 10000;
+        box-shadow: 0 -4px 12px rgba(255,77,79,0.25);
 }
 
 #taskbar-inner {
-	border-top: solid 1px var(--redmond-border-highlight);
-	width: 100%;
-	height: 28px;
-	padding: 2px;
-	border-radius: 0;
+        border-top: solid 1px var(--redmond-border-highlight);
+        width: 100%;
+        height: 28px;
+        padding: 2px;
+        border-radius: 0;
+        background: linear-gradient(90deg, rgba(12,12,16,0.85) 0%, rgba(255,77,79,0.28) 100%);
 }
 
 span.button-outer {
@@ -93,36 +98,36 @@ span.button-outer:active, span.button-outer.activated {
 }
 
 button.system-button {
-	min-width: 50px;
-	height: 22px;
-	border: solid 1px;
-	padding:0;
-	padding-left: 5px;
-	padding-right: 5px;
-	border-top-color: var(--redmond-border-highlight);
-	border-left-color: var(--redmond-border-highlight);
-	border-right-color: var(--redmond-border-dark);
-	border-bottom-color: var(--redmond-border-dark);
-	float: left;
-	background: var(--redmond-surface);
-	background-color: var(--redmond-surface);
-	color: var(--redmond-text);
+        min-width: 50px;
+        height: 22px;
+        border: solid 1px;
+        padding:0;
+        padding-left: 5px;
+        padding-right: 5px;
+        border-top-color: var(--redmond-border-highlight);
+        border-left-color: var(--redmond-border-highlight);
+        border-right-color: var(--redmond-border-dark);
+        border-bottom-color: var(--redmond-border-dark);
+        float: left;
+        background: linear-gradient(180deg, rgba(33,33,41,0.95) 0%, rgba(12,12,18,0.95) 100%);
+        background-color: var(--redmond-surface);
+        color: var(--redmond-text);
 }
 
 input.system-field {
-	width: 100%;
-	height: 22px;
-	border: solid 1px;
-	border-top: solid 2px;
-	border-left: solid 2px;
-	border-bottom-color: var(--redmond-border-highlight);
-	border-right-color: var(--redmond-border-highlight);
-	border-left-color: var(--redmond-border-dark);
-	border-top-color: var(--redmond-border-dark);
-	background: var(--redmond-surface);
-	color: var(--redmond-text);
-	padding-left: 2px;
-	padding-right: 2px;
+        width: 100%;
+        height: 22px;
+        border: solid 1px;
+        border-top: solid 2px;
+        border-left: solid 2px;
+        border-bottom-color: var(--redmond-border-highlight);
+        border-right-color: var(--redmond-border-highlight);
+        border-left-color: var(--redmond-border-dark);
+        border-top-color: var(--redmond-border-dark);
+        background: linear-gradient(180deg, rgba(25,25,33,0.95) 0%, rgba(10,10,16,0.95) 100%);
+        color: var(--redmond-text);
+        padding-left: 2px;
+        padding-right: 2px;
 }
 
 span.button-outer.activated>button.system-button:active, span.button-outer.activated>button.system-button {
@@ -148,20 +153,22 @@ button.system-button>span {
 }
 
 #taskbar-clock {
-	float: right;
-	display: inline-block;
-	border: solid 1px;
-	border-bottom-color: var(--redmond-border-highlight);
-	border-right-color: var(--redmond-border-highlight);
-	border-top-color: var(--redmond-border-dark);
-	border-left-color: var(--redmond-border-dark);
-	height: 23px;
-	margin-right: 5px;
-	line-height: 24px;
-	text-align: right;
-	padding-left: 5px;
-	padding-right: 5px;
-	background: var(--redmond-surface);
+        float: right;
+        display: inline-block;
+        border: solid 1px;
+        border-bottom-color: var(--redmond-border-highlight);
+        border-right-color: var(--redmond-border-highlight);
+        border-top-color: var(--redmond-border-dark);
+        border-left-color: var(--redmond-border-dark);
+        height: 23px;
+        margin-right: 5px;
+        line-height: 24px;
+        text-align: right;
+        padding-left: 5px;
+        padding-right: 5px;
+        background: linear-gradient(180deg, rgba(33,33,41,0.95) 0%, rgba(12,12,18,0.95) 100%);
+        color: var(--redmond-text);
+        text-shadow: 0 0 6px rgba(255,77,79,0.45);
 }
 
 #desktop-area {
@@ -194,17 +201,17 @@ button.system-button>span {
 }
 
 #start-menu-wrapper {
-	position: fixed;
-	bottom: 30px;
-	left: 0;
-	max-width: 100%;
-	width: 382px;
-	height: 426px;
-	max-height: 100%;
-	display: none;
-	background: var(--redmond-surface-alt);
-	background-color: var(--redmond-surface-alt);
-	border: solid 1px;
+        position: fixed;
+        bottom: 30px;
+        left: 0;
+        max-width: 100%;
+        width: 382px;
+        height: 426px;
+        max-height: 100%;
+        display: none;
+        background: linear-gradient(180deg, rgba(22,22,30,0.98) 0%, rgba(10,10,16,0.98) 100%);
+        background-color: var(--redmond-surface-alt);
+        border: solid 1px;
 	border-top-color: var(--redmond-border-highlight);
 	border-left-color: var(--redmond-border-highlight);
 	border-right-color: var(--redmond-border-dark);
@@ -213,32 +220,33 @@ button.system-button>span {
 }
 
 #start-menu-inner {
-	border-top: solid 1px var(--redmond-border-highlight);
-	width: 100%;
-	height: 100%;
-	background: var(--redmond-surface);
-	float: left;
+        border-top: solid 1px var(--redmond-border-highlight);
+        width: 100%;
+        height: 100%;
+        background: linear-gradient(135deg, rgba(15,15,20,0.98) 0%, rgba(255,77,79,0.15) 100%);
+        float: left;
 }
 
 #start-menu-user-bar {
-	position: absolute;
-	top: 0;
-	height: 40px;
-	line-height: 40px;
-	width: 100%;
-	background: linear-gradient(90deg, rgba(15,23,42,0.95) 0%, rgba(37,99,235,0.75) 100%);
-	z-index: 10000;
+        position: absolute;
+        top: 0;
+        height: 40px;
+        line-height: 40px;
+        width: 100%;
+        background: linear-gradient(90deg, rgba(12,12,16,0.95) 0%, rgba(255,77,79,0.75) 100%);
+        z-index: 10000;
 }
 
 p.current-user {
-	line-height: 38px;
-	font-size: 26px;
-	color: #FFF;
-	margin: 0;
-	text-align: left;
-	margin-right: 5px;
-	margin-left: 10px;
-	font-style: italic;
+        line-height: 38px;
+        font-size: 26px;
+        color: #FFF;
+        margin: 0;
+        text-align: left;
+        margin-right: 5px;
+        margin-left: 10px;
+        font-style: italic;
+        text-shadow: 0 0 8px rgba(255,77,79,0.6);
 }
 
 p.current-user>img {
@@ -264,22 +272,23 @@ p.current-user>img {
 }
 
 #start-menu-login-bar-outer {
-	position: absolute;
-	bottom: 0;
-	display: block;
-	width: 100%;
-	height: 40px;
-	border-top: solid 1px var(--redmond-border-dark);
-	background: var(--redmond-surface-alt);
-	background-color: var(--redmond-surface-alt);
-	z-index: 1000;
+        position: absolute;
+        bottom: 0;
+        display: block;
+        width: 100%;
+        height: 40px;
+        border-top: solid 1px var(--redmond-border-dark);
+        background: linear-gradient(180deg, rgba(24,24,32,0.95) 0%, rgba(255,77,79,0.22) 100%);
+        background-color: var(--redmond-surface-alt);
+        z-index: 1000;
 }
 
 #start-menu-login-bar-inner {
-	display: block;
-	float: left;
-	width: 100%;
-	border-top: solid 1px var(--redmond-border-highlight);
+        display: block;
+        float: left;
+        width: 100%;
+        border-top: solid 1px var(--redmond-border-highlight);
+        background: linear-gradient(90deg, rgba(12,12,16,0.85) 0%, rgba(255,77,79,0.18) 100%);
 }
 
 .start-menu-bottom-bar-command {
@@ -312,10 +321,16 @@ p.current-user>img {
 }
 
 #start-menu-posts>a , #start-menu-content-links>a, #start-menu-archive-link-wrapper>li{
-	padding: 5px;
-	cursor: pointer;
-	display: block;
-	color: var(--redmond-text);
+        padding: 5px;
+        cursor: pointer;
+        display: block;
+        color: var(--redmond-text);
+}
+
+.start-menu-empty {
+        display: block;
+        padding: 10px;
+        color: var(--redmond-text-muted);
 }
 
 #start-menu-content-links>a.seperator , #start-menu-archive-link-wrapper>li.seperator{
@@ -416,24 +431,28 @@ ul.archives-inner-wrapper>li:hover, ul.archives-inner-wrapper>li:focus, ul.archi
 }
 
 div.redmond-dialog-window {
-	z-index: 500;
-	background: var(--redmond-surface-alt);
-	background-color: var(--redmond-surface-alt);
-	min-height: 20px;
-	border: solid 1px;
-	border-top-color: var(--redmond-border-highlight);
-	border-left-color: var(--redmond-border-highlight);
-	border-right-color: var(--redmond-border-dark);
-	border-bottom-color: var(--redmond-border-dark);
-	display: inline-block;
-	max-width: 100%;
-	max-height: 100%;
-	position: absolute !important;
+        z-index: 500;
+        background: linear-gradient(180deg, rgba(25,25,34,0.98) 0%, rgba(10,10,14,0.98) 100%);
+        background-color: var(--redmond-surface-alt);
+        min-height: 20px;
+        border: solid 1px;
+        border-top-color: var(--redmond-border-highlight);
+        border-left-color: var(--redmond-border-highlight);
+        border-right-color: var(--redmond-border-dark);
+        border-bottom-color: var(--redmond-border-dark);
+        display: inline-block;
+        max-width: 100%;
+        max-height: 100%;
+        position: absolute !important;
+}
+
+div.redmond-dialog-window.redmond-dialog-hidden {
+        display: none !important;
 }
 
 div.redmond-dialog-window>.ui-dialog-content, div.redmond-dialog-window>.ui-dialog-titlebar {
-	min-width: 300px;
-	display: block;
+        min-width: 300px;
+        display: block;
 }
 
 div.redmond-dialog-window>.ui-dialog-content {
@@ -448,11 +467,11 @@ div.redmond-dialog-window>.ui-dialog-content>article {
 }
 
 div.redmond-dialog-window>.ui-dialog-titlebar {
-	background: linear-gradient(90deg, rgba(15,23,42,0.95) 0%, rgba(96,165,250,0.75) 100%);
-	color: var(--redmond-text);
-	height: auto;
-	cursor: move;
-	padding: 2px;
+        background: linear-gradient(90deg, rgba(12,12,16,0.95) 0%, rgba(255,77,79,0.75) 100%);
+        color: var(--redmond-text);
+        height: auto;
+        cursor: move;
+        padding: 2px;
 }
 
 div.redmond-dialog-window>.ui-dialog-titlebar>span {
@@ -464,33 +483,57 @@ div.redmond-dialog-window>.ui-dialog-titlebar>span {
 }
 
 div.redmond-dialog-window>.ui-dialog-titlebar>button {
-	position: absolute;
-	top: 1px;
-	right: 1px;
-	background: var(--redmond-surface);
-	background-color: var(--redmond-surface);
-	min-height: 20px;
-	border: solid 1px;
-	border-top-color: var(--redmond-border-highlight);
-	border-left-color: var(--redmond-border-highlight);
-	border-right-color: var(--redmond-border-dark);
-	border-bottom-color: var(--redmond-border-dark);
-	display: inline-block;
-	padding: 0;
-	line-height: 0;
-	height: auto;
-	width: 20px;
-	font-weight: 700;
-	color: var(--redmond-text);
+        position: absolute;
+        top: 1px;
+        right: 1px;
+        background: linear-gradient(180deg, rgba(36,36,44,0.95) 0%, rgba(14,14,20,0.95) 100%);
+        background-color: var(--redmond-surface);
+        min-height: 20px;
+        border: solid 1px;
+        border-top-color: var(--redmond-border-highlight);
+        border-left-color: var(--redmond-border-highlight);
+        border-right-color: var(--redmond-border-dark);
+        border-bottom-color: var(--redmond-border-dark);
+        display: inline-block;
+        padding: 0;
+        line-height: 1;
+        height: auto;
+        width: 22px;
+        font-weight: 700;
+        color: var(--redmond-text);
+}
+
+div.redmond-dialog-window>.ui-dialog-titlebar>button.redmond-close-button {
+        display: flex;
+        align-items: center;
+        justify-content: center;
+        font-size: 16px;
+        padding: 0;
+}
+
+div.redmond-dialog-window>.ui-dialog-titlebar>button.redmond-close-button .redmond-close-text {
+        line-height: 1;
+        font-size: 16px;
+        display: block;
+}
+
+div.redmond-dialog-window>.ui-dialog-titlebar>button.redmond-close-button:focus-visible {
+        outline: 2px solid var(--redmond-accent);
+        outline-offset: 1px;
+}
+
+div.redmond-dialog-window>.ui-dialog-titlebar>button.redmond-close-button:hover {
+        background: linear-gradient(180deg, rgba(255,77,79,0.35) 0%, rgba(36,36,44,0.95) 100%);
+        color: var(--redmond-text);
 }
 
 div.redmond-dialog-window>div.ui-dialog-content {
-	background: var(--redmond-surface);
-	overflow-y: auto;
-	border: solid 1px;
-	border-top-color: var(--redmond-border-highlight);
-	border-left-color: var(--redmond-border-highlight);
-	border-right-color: var(--redmond-border-dark);
+        background: linear-gradient(180deg, rgba(20,20,28,0.98) 0%, rgba(12,12,16,0.98) 100%);
+        overflow-y: auto;
+        border: solid 1px;
+        border-top-color: var(--redmond-border-highlight);
+        border-left-color: var(--redmond-border-highlight);
+        border-right-color: var(--redmond-border-dark);
 	border-bottom-color: var(--redmond-border-dark);
 	min-height: 50px !important;
 	position: relative;
@@ -529,13 +572,13 @@ div.redmond-dialog-window>div.ui-dialog-content {
 }
 
 div.file-bar {
-	display: block;
-	width: 100%;
-	min-height: 10px;
-	background: var(--redmond-surface-alt);
-	background-color: var(--redmond-surface-alt);
-	position: absolute;
-	border-right: solid 1px var(--redmond-border-dark);
+        display: block;
+        width: 100%;
+        min-height: 10px;
+        background: linear-gradient(180deg, rgba(32,32,42,0.98) 0%, rgba(12,12,18,0.98) 100%);
+        background-color: var(--redmond-surface-alt);
+        position: absolute;
+        border-right: solid 1px var(--redmond-border-dark);
 }
 
 div.file-bar>ul {
@@ -559,15 +602,15 @@ div.file-bar>ul>li:hover, div.file-bar>ul>li:focus, div.file-bar>ul>li:active , 
 }
 
 div.file-bar>ul>li>ul {
-	display: none;
-	position: absolute;
-	top: 25px;
-	left: 1px;
-	min-height: 10px;
-	background: var(--redmond-surface);
-	background-color: var(--redmond-surface);
-	color: var(--redmond-text);
-	list-style-type: none;
+        display: none;
+        position: absolute;
+        top: 25px;
+        left: 1px;
+        min-height: 10px;
+        background: linear-gradient(180deg, rgba(25,25,33,0.98) 0%, rgba(8,8,12,0.98) 100%);
+        background-color: var(--redmond-surface);
+        color: var(--redmond-text);
+        list-style-type: none;
 	min-width: 100px;
 	padding-left: 0;
 	border: solid 1px;


### PR DESCRIPTION
## Summary
- ensure the dialog close control always resolves the associated window before hiding the wrapper so the button reliably dismisses pages
- keep floating windows capped to roughly half the viewport while subtracting menu chrome so content areas always expose a scrollbar
- populate the Start menu with recent posts or pages and show a styled fallback message when no content is available

## Testing
- not run (not requested)

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_690fa6ee89c8832a842139bf4060478b)