### PR TITLE
Improve dialog close handling and desktop link behavior

### DIFF
--- a/bin/client.php
+++ b/bin/client.php
@@ -576,7 +576,13 @@
 		foreach ( $cells as $cell ) {
 		$type = $cell['type'];
 		$html .= '		<td>' . "\r\n";
-		$html .= '			<a href="' . esc_url( $cell['url'] ) . '" data-type="' . esc_html( $type ) . '" title="' . $cell['fulltitle'] . '"';
+		$html .= '			<a href="' . esc_url( $cell['url'] ) . '" data-type="' . esc_html( $type ) . '"';
+
+		if ( 'regular' === $type ) {
+			$html .= ' class="desktop-window-link"';
+		}
+
+		$html .= ' title="' . $cell['fulltitle'] . '"';
 		switch ( $type ) {
 			case 'regular':
 				$html .= ' data-post-id="' . intval( $cell['id'] ) . '"';
@@ -619,6 +625,8 @@
 					'title' => true,
 					'data-post-id' => true,
 					'data-category-id' => true,
+					'data-author-id' => true,
+					'class' => true,
 				),
 				'img' => array(
 					'src' => true,

--- a/functions.js
+++ b/functions.js
@@ -5,26 +5,41 @@ var sounds = {
 };
 
 jQuery(function() {
-	startSystemClock();
-	handle_start_menu();
-	jQuery('a').on('click',function(e){
-		if( typeof( jQuery(this).attr('id') ) === 'undefined' || 
-			( jQuery(this).attr('id') !== 'home-start-menu-link' 
-				&& jQuery(this).attr('id') !== 'new-post-start-menu-link' 
-				&& jQuery(this).attr('id') !== 'control-panel-start-menu-link'
-				&& jQuery(this).attr('id') !== 'start-menu-bottom-bar-logout'
-				&& jQuery(this).attr('id') !== 'start-menu-bottom-bar-register'
-				&& jQuery(this).attr('id') !== 'start-menu-bottom-bar-login'
-				&& jQuery(this).attr('id') !== 'system-info-start-menu-link' 
-				&& jQuery(this).attr('id') !== 'my-documents-start-menu-link'
-				&& jQuery(this).attr('id') !== 'my-tags-start-menu-link'
-				&& jQuery(this).attr('id') !== 'authors-start-menu-link'
-				&& jQuery(this).attr('id') !== 'system-search-start-menu-link' )
-		) {
-			e.preventDefault();
-			open_this_as_redmond_dialog(this);
-		}
-	});
+        startSystemClock();
+        handle_start_menu();
+        jQuery('a')
+                .off('click.redmondGlobal')
+                .on('click.redmondGlobal', function( e ) {
+                        var $a = jQuery(this);
+
+                        if ( $a.hasClass('redmond-close-window') ) {
+                                return;
+                        }
+
+                        var id = $a.attr('id');
+
+                        if (
+                                typeof id !== 'undefined' &&
+                                (
+                                        id === 'home-start-menu-link' ||
+                                        id === 'new-post-start-menu-link' ||
+                                        id === 'control-panel-start-menu-link' ||
+                                        id === 'start-menu-bottom-bar-logout' ||
+                                        id === 'start-menu-bottom-bar-register' ||
+                                        id === 'start-menu-bottom-bar-login' ||
+                                        id === 'system-info-start-menu-link' ||
+                                        id === 'my-documents-start-menu-link' ||
+                                        id === 'my-tags-start-menu-link' ||
+                                        id === 'authors-start-menu-link' ||
+                                        id === 'system-search-start-menu-link'
+                                )
+                        ) {
+                                return;
+                        }
+
+                        e.preventDefault();
+                        open_this_as_redmond_dialog(this);
+                });
 	jQuery(window).on('checkOpenWindows',function() {
 		checkOpenWindows();
 	});
@@ -50,13 +65,58 @@ jQuery(function() {
         if ( typeof redmond_adjust_dialog_sizes === 'function' ) {
                 redmond_adjust_dialog_sizes();
         }
+});
 
-        jQuery(window).on('resize',function() {
+jQuery(document).on('click', '.redmond-close-window', function ( e ) {
+        e.preventDefault();
+        e.stopPropagation();
+
+        var $dialog = jQuery(this).closest('.ui-dialog');
+
+        if ( $dialog.length ) {
+                var $content = $dialog.find('.ui-dialog-content');
+
+                if ( $content.length && typeof $content.dialog === 'function' ) {
+                        $content.dialog('close');
+                }
+                else {
+                        $dialog.hide();
+                }
+        }
+});
+
+jQuery(window)
+        .off('resize.redmond')
+        .on('resize.redmond', function () {
+                var maxHeight = jQuery(window).height() * 0.9;
+
+                jQuery('div.redmond-dialog-window').each(function () {
+                        var $window = jQuery(this);
+
+                        if ( $window.height() > maxHeight ) {
+                                $window.css({
+                                        height: maxHeight,
+                                        'padding-bottom': 20
+                                });
+                        }
+                        else {
+                                $window.css({
+                                        height: 'auto',
+                                        'padding-bottom': 0
+                                });
+                        }
+
+                        $window.find('.ui-dialog-content').css({
+                                'overflow-y': 'auto',
+                                'overflow-x': 'auto'
+                        });
+                });
+
                 if ( typeof redmond_adjust_dialog_sizes === 'function' ) {
                         redmond_adjust_dialog_sizes();
                 }
-        });
-});
+        })
+        .trigger('resize.redmond');
 
 function checkOpenWindows() {
         var processList = '';

--- a/resources/redmond-dialogs.js
+++ b/resources/redmond-dialogs.js
@@ -168,25 +168,27 @@ function redmond_style_close_button( closeButton ) {
                 return;
         }
 
+        var titleBar = closeButton.closest('.ui-dialog-titlebar');
+
+        if ( ! titleBar.length ) {
+                return;
+        }
+
+        if ( titleBar.find('.redmond-close-window').length ) {
+                closeButton.remove();
+                return;
+        }
+
         var closeLabel = ( window.redmond_terms && redmond_terms.close ) ? redmond_terms.close : 'Close';
+        var closeLink = jQuery('<a href="#" class="redmond-close-window redmond-close-button" role="button"></a>');
 
-        closeButton
-                .removeClass('ui-button-icon-only')
-                .addClass('redmond-close-button')
-                .attr('type', 'button')
+        closeLink
                 .attr('title', closeLabel)
-                .attr('aria-label', closeLabel);
+                .attr('aria-label', closeLabel)
+                .append('<span class="redmond-close-text" aria-hidden="true">&times;</span>');
 
-        closeButton.find('span.ui-icon').remove();
-        closeButton.find('span.ui-button-icon-space').remove();
-        closeButton
-                .contents()
-                .filter(function(){
-                        return this.nodeType === 3;
-                })
-                .remove();
-        closeButton.find('span.redmond-close-text').remove();
-        closeButton.append('<span class="redmond-close-text" aria-hidden="true">&times;</span>');
+        titleBar.append( closeLink );
+        closeButton.remove();
 }
 
 function redmond_adjust_dialog_sizes() {

--- a/style.css
+++ b/style.css
@@ -575,7 +575,7 @@ div.redmond-dialog-window>.ui-dialog-titlebar>span {
 	padding-left: 25px;
 }
 
-div.redmond-dialog-window>.ui-dialog-titlebar>button {
+div.redmond-dialog-window>.ui-dialog-titlebar>.redmond-close-button {
         position: absolute;
         top: 1px;
         right: 1px;
@@ -587,35 +587,34 @@ div.redmond-dialog-window>.ui-dialog-titlebar>button {
         border-left-color: var(--redmond-border-highlight);
         border-right-color: var(--redmond-border-dark);
         border-bottom-color: var(--redmond-border-dark);
-        display: inline-block;
+        display: inline-flex;
+        align-items: center;
+        justify-content: center;
         padding: 0;
         line-height: 1;
         height: auto;
         width: 22px;
         font-weight: 700;
         color: var(--redmond-text);
+        text-decoration: none;
 }
 
-div.redmond-dialog-window>.ui-dialog-titlebar>button.redmond-close-button {
-        display: flex;
-        align-items: center;
-        justify-content: center;
+div.redmond-dialog-window>.ui-dialog-titlebar>.redmond-close-button {
         font-size: 16px;
-        padding: 0;
 }
 
-div.redmond-dialog-window>.ui-dialog-titlebar>button.redmond-close-button .redmond-close-text {
+div.redmond-dialog-window>.ui-dialog-titlebar>.redmond-close-button .redmond-close-text {
         line-height: 1;
         font-size: 16px;
         display: block;
 }
 
-div.redmond-dialog-window>.ui-dialog-titlebar>button.redmond-close-button:focus-visible {
+div.redmond-dialog-window>.ui-dialog-titlebar>.redmond-close-button:focus-visible {
         outline: 2px solid var(--redmond-accent);
         outline-offset: 1px;
 }
 
-div.redmond-dialog-window>.ui-dialog-titlebar>button.redmond-close-button:hover {
+div.redmond-dialog-window>.ui-dialog-titlebar>.redmond-close-button:hover {
         background: linear-gradient(180deg, rgba(255,77,79,0.35) 0%, rgba(36,36,44,0.95) 100%);
         color: var(--redmond-text);
 }
@@ -627,10 +626,19 @@ div.redmond-dialog-window>div.ui-dialog-content {
         border-top-color: var(--redmond-border-highlight);
         border-left-color: var(--redmond-border-highlight);
         border-right-color: var(--redmond-border-dark);
-	border-bottom-color: var(--redmond-border-dark);
+        border-bottom-color: var(--redmond-border-dark);
         min-height: 50px !important;
         position: relative;
         box-sizing: border-box;
+}
+
+.ui-dialog .ui-dialog-content {
+        overflow-y: auto;
+        overflow-x: auto;
+}
+
+.ui-resizable-handle {
+        display: none !important;
 }
 
 .redmond-comment-window .ui-dialog-content,


### PR DESCRIPTION
## Summary
- replace the global anchor handler and add a delegated close control so Redmond windows can be dismissed without interfering with other links
- refresh resize logic and dialog styling to keep window content scrollable and hide the native resize grip
- tag desktop shortcuts for posts so they open in Redmond dialogs without full page loads

## Testing
- php -l bin/client.php

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6911dccc77608327ad5109fe5614d0e2)