### PR TITLE
Fix dialog link handling and scrollbar behavior

### DIFF
--- a/functions.js
+++ b/functions.js
@@ -12,6 +12,10 @@ jQuery(function() {
                 .on('click.redmondGlobal', function( e ) {
                         var $a = jQuery(this);
 
+                        if ( $a.closest('.ui-dialog').length ) {
+                                return;
+                        }
+
                         if ( $a.hasClass('redmond-close-window') ) {
                                 return;
                         }
@@ -542,9 +546,16 @@ function redmondEnsureDialogScroll( dialogContent ) {
                         'overflow-y': 'auto',
                         'overflow-x': 'auto',
                 });
+
+                wrapper.css({
+                        'max-height': '100%',
+                        overflow: 'visible',
+                });
         }
 
-        redmond_adjust_dialog_sizes();
+        if ( typeof redmond_adjust_dialog_sizes === 'function' ) {
+                redmond_adjust_dialog_sizes();
+        }
 }
 
 function redmondCopyToClipboard( text ) {


### PR DESCRIPTION
## Summary
- Prevent the global link handler from intercepting clicks inside dialogs so dialog controls continue to work
- Ensure dialog content and wrappers keep scrollbars available without requiring manual resizing

## Testing
- Not run (not requested)

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6911e28195d48327a44742f7f946586f)